### PR TITLE
Use RouteCache to clean cached routes

### DIFF
--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -8,8 +8,8 @@ describe Blog, type: :model do
   end
 
   describe 'A blog' do
-    before(:each) do
-      Rails.cache.clear
+    before do
+      RouteCache.clear
       @blog = Blog.new
     end
 

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -24,10 +24,9 @@ describe Note, type: :model do
     end
 
     describe 'permalink' do
-      let(:note) do
-        Rails.cache.clear
-        create(:note, body: 'àé')
-      end
+      before { RouteCache.clear }
+
+      let(:note) { create(:note, body: 'àé') }
 
       it { expect(note.permalink).to eq("#{note.id}-ae") }
       it { expect(note.permalink_url).to eq("#{blog.base_url}/note/#{note.id}-ae") }

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -13,8 +13,10 @@ describe Page, type: :model do
 
   describe 'permalink' do
     context 'with an existing page' do
-      before(:each) { Rails.cache.clear }
+      before(:each) { RouteCache.clear }
+
       let(:page) { create(:page, name: 'page_one') }
+
       it { expect(page.permalink_url).to eq('http://myblog.net/pages/page_one') }
     end
   end


### PR DESCRIPTION
Rails.cache.clear fails when the cache path doesn't exist
It causes random failures in Travis CI
