### PR TITLE
Use correct query string params in dashboard links

### DIFF
--- a/app/views/admin/dashboard/_welcome.html.erb
+++ b/app/views/admin/dashboard/_welcome.html.erb
@@ -19,9 +19,9 @@
       <%  if current_user.can_access_to_feedback? %>
         <h4 class='page-header'><%= t(".feedback") %></h4>
         <p><%= link_to(t('.comments_count', count: @statcomments), controller: 'admin/feedback') %></p>
-        <p><%= link_to(t('.approved_count', count: @confirmed), controller: 'admin/feedback', "ham" => "f") %></p>
-        <p><%= link_to(t('.unconfirmed_count', count: @unconfirmed), controller: 'admin/feedback', "presumed_ham" => "f") %></p>
-        <p><%= link_to(t(".spam_count", count: @statspam), controller: 'admin/feedback', "spam" => "f") %></p>
+        <p><%= link_to(t('.approved_count', count: @confirmed), controller: 'admin/feedback', only: 'ham') %></p>
+        <p><%= link_to(t('.unconfirmed_count', count: @unconfirmed), controller: 'admin/feedback', only: 'unapproved') %></p>
+        <p><%= link_to(t(".spam_count", count: @statspam), controller: 'admin/feedback', only: 'spam') %></p>
       <% end %>      
     </div>
   </div>

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -46,11 +46,11 @@ describe Admin::DashboardController, type: :controller do
     end
 
     it 'should have a link to Spam' do
-      expect(response.body).to have_selector("a[href='/admin/feedback?spam=f']", text: 'no spam')
+      expect(response.body).to have_selector("a[href='/admin/feedback?only=spam']", text: 'no spam')
     end
 
     it 'should have a link to Spam queue' do
-      expect(response.body).to have_selector("a[href='/admin/feedback?presumed_ham=f']", text: 'no unconfirmed')
+      expect(response.body).to have_selector("a[href='/admin/feedback?only=unapproved']", text: 'no unconfirmed')
     end
   end
 
@@ -93,11 +93,11 @@ describe Admin::DashboardController, type: :controller do
     end
 
     it 'should have a link to Spam' do
-      expect(response.body).to have_selector("a[href='/admin/feedback?spam=f']", text: 'no spam')
+      expect(response.body).to have_selector("a[href='/admin/feedback?only=spam']", text: 'no spam')
     end
 
     it 'should have a link to Spam queue' do
-      expect(response.body).to have_selector("a[href='/admin/feedback?presumed_ham=f']", text: 'no unconfirmed')
+      expect(response.body).to have_selector("a[href='/admin/feedback?only=unapproved']", text: 'no unconfirmed')
     end
   end
 
@@ -144,11 +144,11 @@ describe Admin::DashboardController, type: :controller do
     end
 
     it 'should not have a link to Spam' do
-      expect(response.body).not_to have_selector("a[href='/admin/feedback?published=f']", text: 'Spam comments:')
+      expect(response.body).not_to have_selector("a[href='/admin/feedback?only=spam']", text: 'no spam')
     end
 
     it 'should not have a link to Spam queue' do
-      expect(response.body).not_to have_selector("a[href='/admin/feedback?presumed_spam=f']", text: 'In your spam queue:')
+      expect(response.body).not_to have_selector("a[href='/admin/feedback?only=unapproved']", text: 'no unconfirmed')
     end
   end
 end


### PR DESCRIPTION
`Admin::FeedbackController#index` expects a filter to be specified in the [`only` param](https://github.com/moneyadviceservice/publify/blob/d8df2bf923a2faf5fab1e18495573fffb926c2a3/app/controllers/admin/feedback_controller.rb#L8).

__NOTE:__ the `unconfirmed` scope only [exists on Feedback](https://github.com/moneyadviceservice/publify/blob/d8df2bf923a2faf5fab1e18495573fffb926c2a3/app/models/feedback.rb#L28) and [not Comment](https://github.com/moneyadviceservice/publify/blob/d8df2bf923a2faf5fab1e18495573fffb926c2a3/app/models/comment.rb#L16) so I've used the `unapproved` scope instead.

I'll see about getting this into upstream as well.