### PR TITLE
adding interactivity to answer reveal

### DIFF
--- a/app/assets/stylesheets/bootstrap.css.scss
+++ b/app/assets/stylesheets/bootstrap.css.scss
@@ -6070,6 +6070,14 @@ button.close {
   padding: 20px;
 }
 
+.modal-body__code {
+  width: 100%;
+  height: 100px;
+  border: 0;
+  resize: none;
+  font-family: courier;
+}
+
 .modal-footer {
   padding: 19px 20px 20px;
   margin-top: 15px;

--- a/app/assets/stylesheets/components/article_body/_collapsible.scss
+++ b/app/assets/stylesheets/components/article_body/_collapsible.scss
@@ -8,6 +8,10 @@ $inline-callout-link-color: $green-leaf;
   @include font-size(24);
   color: $heading-color-secondary;
   margin-bottom: baseline-unit(5);
+
+  .js & {
+    margin-bottom: baseline-unit(8);
+  }
 }
 
 .collapsible__trigger {
@@ -28,6 +32,8 @@ $inline-callout-link-color: $green-leaf;
     text-align: left;
     padding-bottom: baseline-unit(4);
     background: linear-gradient(to bottom, transparent 60%, $silver 60%, $silver 61%, transparent 61%);
+    position: relative;
+    bottom:baseline-unit(5.6);
   }
 }
 
@@ -64,20 +70,13 @@ $inline-callout-link-color: $green-leaf;
   }
 
   .inline-callout {
-    padding-bottom: baseline-unit(16);
+    padding-bottom: baseline-unit(10);
     margin-bottom: 0;
-
-    a {
-      color: $inline-callout-link-color;
-    }
-
-    .inline-callout__arrow-path {
-      stroke: $inline-callout-link-color;
-    }
   }
 
   p:first-of-type {
     @include font-size(18);
+    color: inherit;
   }
 }
 

--- a/app/assets/stylesheets/components/article_body/_collapsible.scss
+++ b/app/assets/stylesheets/components/article_body/_collapsible.scss
@@ -8,17 +8,99 @@
   margin-bottom: baseline-unit(5);
 }
 
-.collapsible__link {
-  position: relative;
-  display: block;
-  padding-bottom: baseline-unit(1);
-  font-weight: $font-weight-bold;
-  border-bottom: $base-border-thin;
+.collapsible__trigger {
+  display: none;
+
+  .js & {
+    display: block;
+    position: relative;
+    transition: margin .5s;
+  }
+
+  .icon {
+    display: none;
+  }
+
+  .unstyled-button {
+    width: 100%;
+    text-align: left;
+    padding-bottom: baseline-unit(4);
+    background: linear-gradient(to bottom, transparent 60%, $silver 60%, $silver 61%, transparent 61%);
+  }
 }
 
-.collapsible__icon {
+.collapsible__trigger-text {
+  display: inline-block;
+  padding: baseline-unit(1) baseline-unit(2) baseline-unit(1) 0;
+  background: $white;
+  color: $deep-cerulean;
+  font-weight: $font-weight-bold;
+
+  .is-active & {
+    display: none;
+  }
+}
+
+.collapsible__trigger-text--hide {
+  display: none;
+
+  .is-active & {
+    display: inline-block;
+  }
+}
+
+.collapsible__reveal {
+  .js & {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.5s cubic-bezier(0, 1.05, 0, 1);
+  }
+
+  &.is-active {
+    max-height: 1500px;
+    transition: max-height 1s;
+  }
+
+  .inline-callout {
+    padding-bottom: baseline-unit(16);
+    margin-bottom: 0;
+
+    a {
+      color: $green-leaf;
+    }
+
+    .inline-callout__arrow-path {
+      stroke: $green-leaf;
+    }
+  }
+}
+
+.plus-icon {
   position: absolute;
-  right: -3px;
-  top: -2px;
+  right: 0;
+  top: 2px;
   width: 60px;
+}
+
+.plus-icon__origin {
+  transform: translate(40px, 40px);
+}
+
+.plus-icon__lines {
+  transition: transform .8s;
+  transform: rotate(0deg) translate(-40px, -40px);
+  transform-origin: 0 0;
+
+  .is-active & {
+    transform: rotate(90deg) translate(-40px, -40px);
+  }
+}
+
+.plus-icon__horizontal-line {
+  transition: transform .8s;
+
+  .is-active & {
+    transform-origin: 0 0;
+    transform: translate(40px) scaleX(0);
+  }
 }

--- a/app/assets/stylesheets/components/article_body/_collapsible.scss
+++ b/app/assets/stylesheets/components/article_body/_collapsible.scss
@@ -1,3 +1,5 @@
+$inline-callout-link-color: $green-leaf;
+
 .collapsible {
   margin: baseline-unit(6) 0 baseline-unit(8) 0;
 }
@@ -66,11 +68,11 @@
     margin-bottom: 0;
 
     a {
-      color: $green-leaf;
+      color: $inline-callout-link-color;
     }
 
     .inline-callout__arrow-path {
-      stroke: $green-leaf;
+      stroke: $inline-callout-link-color;
     }
   }
 }

--- a/app/assets/stylesheets/components/article_body/_collapsible.scss
+++ b/app/assets/stylesheets/components/article_body/_collapsible.scss
@@ -75,6 +75,10 @@ $inline-callout-link-color: $green-leaf;
       stroke: $inline-callout-link-color;
     }
   }
+
+  p:first-of-type {
+    @include font-size(18);
+  }
 }
 
 .plus-icon {

--- a/app/assets/stylesheets/components/article_body/_collapsible.scss
+++ b/app/assets/stylesheets/components/article_body/_collapsible.scss
@@ -98,11 +98,19 @@ $inline-callout-link-color: $green-leaf;
   }
 }
 
-.plus-icon__horizontal-line {
+.plus-icon__line {
+  stroke: #fff;
+}
+
+.plus-icon__line--horizontal {
   transition: transform .8s;
 
   .is-active & {
     transform-origin: 0 0;
     transform: translate(40px) scaleX(0);
   }
+}
+
+.plus-icon__circle {
+  fill: #0076AB;
 }

--- a/app/assets/stylesheets/components/article_body/_inline_callout.scss
+++ b/app/assets/stylesheets/components/article_body/_inline_callout.scss
@@ -22,6 +22,15 @@
   background-color: white;
 }
 
+.inline-callout__text[href^="http://www.moneyadviceservice.org.uk"],
+.inline-callout__text[href^="https://www.moneyadviceservice.org.uk"] {
+  color: $inline-callout-link-color;
+
+  .inline-callout__arrow-path {
+    stroke: $inline-callout-link-color;
+  }
+}
+
 .inline-callout__arrow {
   float: right;
   position: absolute;

--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -233,9 +233,9 @@
       </div>
       <div class="modal-body">
         <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button.</p>
-        <pre id="ma_says--snippet-container">
-&lt;hr class=&quot;snippet&quot; data-snippet-name=&quot;inlinecallout&quot; data-snippet-text=&quot;<span style="background:red;color:#fff;">[ENTER LINK TEXT HERE]</span>&quot; data-snippet-url=&quot;<span style="background:red;color:#fff;">[ENTER LINK URL HERE]</span>&quot; /&gt;
-        </pre>
+        <textarea disabled="true" class="modal-body__code">
+<hr class="snippet" data-snippet-name="inlinecallout" data-snippet-text="[ENTER LINK TEXT HERE]" data-snippet-url="[ENTER LINK URL HERE]" />
+        </textarea>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('.close_modal') %></button>
@@ -252,9 +252,9 @@
       </div>
       <div class='modal-body'>
         <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button.</p>
-        <pre id='ma_says--snippet-container'>
-&lt;hr class=&quot;snippet&quot; data-snippet-name=&quot;masays&quot; data-snippet-text=&quot;<span style="background:red;color:#fff;">[ENTER LINK TEXT HERE]</span>&quot; data-snippet-url=&quot;<span style="background:red;color:#fff;">[ENTER LINK URL HERE]</span>&quot; /&gt;
-        </pre>
+        <textarea disabled="true" class="modal-body__code">
+<hr class="snippet" data-snippet-name="masays" data-snippet-text="[ENTER LINK TEXT HERE]" data-snippet-url="[ENTER LINK URL HERE]" />
+        </textarea>
       </div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-default' data-dismiss='modal'><%= t('.close_modal') %></button>
@@ -271,9 +271,9 @@
       </div>
       <div class="modal-body">
         <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button. <b>Note:</b> Add a \n to the answer to start a new paragraph.</p>
-        <pre id="ma_says--snippet-container">
-&lt;hr class=&quot;snippet&quot; data-snippet-name=&quot;answerreveal&quot; data-snippet-text-question=&quot;<span style="background:red;color:#fff;">[ENTER QUESTION TEXT HERE]</span>&quot; data-snippet-text-answer=&quot;<span style="background:red;color:#fff;">[ENTER ANSWER TEXT HERE]</span>&quot; data-snippet-text-callout=&quot;<span style="background:red;color:#fff;">[ENTER CALLOUT TEXT HERE]</span>&quot; data-snippet-url-callout=&quot;<span style="background:red;color:#fff;">[ENTER CALLOUT URL HERE]</span>&quot; /&gt;
-        </pre>
+        <textarea disabled="true" class="modal-body__code">
+<hr class="snippet" data-snippet-name="answerreveal" data-snippet-text-question="[ENTER QUESTION TEXT HERE]" data-snippet-text-answer="[ENTER ANSWER TEXT HERE]" data-snippet-text-callout="[ENTER CALLOUT TEXT HERE]" data-snippet-url-callout="[ENTER CALLOUT URL HERE]" />
+        </textarea>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('.close_modal') %></button>

--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -39,6 +39,9 @@
         <div class="article-callout">
           <button class="btn btn-success" data-toggle="modal" data-target="#inlineCallout">Inline Callout</button>
         </div>
+        <div class="article-callout">
+          <button class="btn btn-success" data-toggle="modal" data-target="#answerReveal">Answer/Reveal</button>
+        </div>
       </div>
     </div>
   </div>
@@ -255,6 +258,25 @@
       </div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-default' data-dismiss='modal'><%= t('.close_modal') %></button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="answerReveal" tabindex="-1" role="dialog" aria-labelledby="answerReveal" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2>Answer/Reveal snippet</h2>
+      </div>
+      <div class="modal-body">
+        <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button.</p>
+        <pre id="ma_says--snippet-container">
+&lt;hr class=&quot;snippet&quot; data-snippet-name=&quot;answerreveal&quot; data-snippet-text-question=&quot;<span style="background:red;color:#fff;">[ENTER QUESTION TEXT HERE]</span>&quot; data-snippet-text-answer=&quot;<span style="background:red;color:#fff;">[ENTER ANSWER TEXT HERE]</span>&quot; data-snippet-text-callout=&quot;<span style="background:red;color:#fff;">[ENTER CALLOUT TEXT HERE]</span>&quot; data-snippet-url-callout=&quot;<span style="background:red;color:#fff;">[ENTER CALLOUT URL HERE]</span>&quot; /&gt;
+        </pre>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('.close_modal') %></button>
       </div>
     </div>
   </div>

--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -270,7 +270,7 @@
         <h2>Answer/Reveal snippet</h2>
       </div>
       <div class="modal-body">
-        <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button.</p>
+        <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button. <b>Note:</b> Add a \n to the answer to start a new paragraph.</p>
         <pre id="ma_says--snippet-container">
 &lt;hr class=&quot;snippet&quot; data-snippet-name=&quot;answerreveal&quot; data-snippet-text-question=&quot;<span style="background:red;color:#fff;">[ENTER QUESTION TEXT HERE]</span>&quot; data-snippet-text-answer=&quot;<span style="background:red;color:#fff;">[ENTER ANSWER TEXT HERE]</span>&quot; data-snippet-text-callout=&quot;<span style="background:red;color:#fff;">[ENTER CALLOUT TEXT HERE]</span>&quot; data-snippet-url-callout=&quot;<span style="background:red;color:#fff;">[ENTER CALLOUT URL HERE]</span>&quot; /&gt;
         </pre>

--- a/app/views/shared/_collapsible.html.erb
+++ b/app/views/shared/_collapsible.html.erb
@@ -1,11 +1,28 @@
 <div class="collapsible">
   <h3 class="collapsible__heading">Do you know what the recommended amount per week a student should spend on food?</h3>
-  <a class="collapsible__link" href="">
-    Reveal the answer
-    <svg class="collapsible__icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" viewBox="10 10 80 80" enable-background="new 0 0 100 100" xml:space="preserve">
-      <circle fill="#0076AB" cx="50" cy="50" r="36"/>
-      <line fill="none" stroke="#FFFFFF" stroke-width="6" stroke-miterlimit="10" x1="50" y1="35" x2="50" y2="65"/>
-      <line fill="none" stroke="#FFFFFF" stroke-width="6" stroke-miterlimit="10" x1="35" y1="50" x2="65" y2="50"/>
+  <div class="collapsible__reveal" data-dough-collapsable-target="2">
+    <p>Bacon ipsum dolor amet short ribs bresaola pig venison kielbasa corned beef swine boudin ball tip ribeye tail porchetta sirloin alcatra. Fatback frankfurter brisket, kevin doner biltong cupim cow sausage ham chuck. Shankle turkey ball tip, bacon picanha short loin pork loin spare ribs frankfurter beef ribs. Filet mignon andouille strip steak pork loin cupim capicola bresaola biltong chuck bacon. Shank ground round fatback porchetta shankle sirloin andouille kevin filet mignon pork belly short loin short ribs spare ribs cow drumstick. Doner cow pig andouille pork, salami tri-tip pork belly leberkas brisket.</p>
+
+    <div class="inline-callout">
+      <a class="inline-callout__text">Get information about student loans
+
+        <svg class="inline-callout__arrow" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="46.9 -3.6 36 57.1" enable-background="new 46.9 -3.6 36 57.1" xml:space="preserve">
+          <polyline class="inline-callout__arrow-path" stroke-width="9" stroke-miterlimit="10" points="50,0 76,25 50,50 "/>
+        </svg>
+      </a>
+    </div>
+  </div>
+  <div class="collapsible__trigger" data-dough-component="Collapsable" data-dough-collapsable-trigger="2">
+    <span class="collapsible__trigger-text">Reveal the answer</span>
+    <span class="collapsible__trigger-text collapsible__trigger-text--hide">Hide answer</span>
+    <svg class="plus-icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 80 80" xml:space="preserve">
+      <g class="plus-icon__origin">
+        <g class="plus-icon__lines">
+          <circle fill="#0076AB" cx="40" cy="40" r="40"/>
+          <line fill="none" stroke="#FFFFFF" stroke-width="6" stroke-miterlimit="10" x1="40" y1="25" x2="40" y2="55"/>
+          <line class="plus-icon__horizontal-line" fill="none" stroke="#FFFFFF" stroke-width="6" stroke-miterlimit="10" x1="25" y1="40" x2="55" y2="40"/>
+        </g>
+      </g>
     </svg>
-  </a>
+  </div>
 </div>

--- a/app/views/shared/_collapsible.html.erb
+++ b/app/views/shared/_collapsible.html.erb
@@ -3,14 +3,7 @@
   <div class="collapsible__reveal" data-dough-collapsable-target="2">
     <p>Bacon ipsum dolor amet short ribs bresaola pig venison kielbasa corned beef swine boudin ball tip ribeye tail porchetta sirloin alcatra. Fatback frankfurter brisket, kevin doner biltong cupim cow sausage ham chuck. Shankle turkey ball tip, bacon picanha short loin pork loin spare ribs frankfurter beef ribs. Filet mignon andouille strip steak pork loin cupim capicola bresaola biltong chuck bacon. Shank ground round fatback porchetta shankle sirloin andouille kevin filet mignon pork belly short loin short ribs spare ribs cow drumstick. Doner cow pig andouille pork, salami tri-tip pork belly leberkas brisket.</p>
 
-    <div class="inline-callout">
-      <a class="inline-callout__text">Get information about student loans
-
-        <svg class="inline-callout__arrow" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="46.9 -3.6 36 57.1" enable-background="new 46.9 -3.6 36 57.1" xml:space="preserve">
-          <polyline class="inline-callout__arrow-path" stroke-width="9" stroke-miterlimit="10" points="50,0 76,25 50,50 "/>
-        </svg>
-      </a>
-    </div>
+    <%= render 'shared/inline_callout' %>
   </div>
   <div class="collapsible__trigger" data-dough-component="Collapsable" data-dough-collapsable-trigger="2">
     <span class="collapsible__trigger-text">Reveal the answer</span>

--- a/app/views/shared/_collapsible.html.erb
+++ b/app/views/shared/_collapsible.html.erb
@@ -1,19 +1,19 @@
 <div class="collapsible">
   <h3 class="collapsible__heading">Do you know what the recommended amount per week a student should spend on food?</h3>
-  <div class="collapsible__reveal" data-dough-collapsable-target="2">
+  <div class="collapsible__reveal" data-dough-collapsable-target="answer_reveal">
     <p>Bacon ipsum dolor amet short ribs bresaola pig venison kielbasa corned beef swine boudin ball tip ribeye tail porchetta sirloin alcatra. Fatback frankfurter brisket, kevin doner biltong cupim cow sausage ham chuck. Shankle turkey ball tip, bacon picanha short loin pork loin spare ribs frankfurter beef ribs. Filet mignon andouille strip steak pork loin cupim capicola bresaola biltong chuck bacon. Shank ground round fatback porchetta shankle sirloin andouille kevin filet mignon pork belly short loin short ribs spare ribs cow drumstick. Doner cow pig andouille pork, salami tri-tip pork belly leberkas brisket.</p>
 
     <%= render 'shared/inline_callout' %>
   </div>
-  <div class="collapsible__trigger" data-dough-component="Collapsable" data-dough-collapsable-trigger="2">
+  <div class="collapsible__trigger" data-dough-component="Collapsable" data-dough-collapsable-trigger="answer_reveal">
     <span class="collapsible__trigger-text">Reveal the answer</span>
     <span class="collapsible__trigger-text collapsible__trigger-text--hide">Hide answer</span>
     <svg class="plus-icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 80 80" xml:space="preserve">
       <g class="plus-icon__origin">
         <g class="plus-icon__lines">
-          <circle fill="#0076AB" cx="40" cy="40" r="40"/>
-          <line fill="none" stroke="#FFFFFF" stroke-width="6" stroke-miterlimit="10" x1="40" y1="25" x2="40" y2="55"/>
-          <line class="plus-icon__horizontal-line" fill="none" stroke="#FFFFFF" stroke-width="6" stroke-miterlimit="10" x1="25" y1="40" x2="55" y2="40"/>
+          <circle class="plus-icon__circle" cx="40" cy="40" r="40"/>
+          <line fill="none" class="plus-icon__line" stroke-width="6" stroke-miterlimit="10" x1="40" y1="25" x2="40" y2="55"/>
+          <line class="plus-icon__line plus-icon__line--horizontal" fill="none" stroke-width="6" stroke-miterlimit="10" x1="25" y1="40" x2="55" y2="40"/>
         </g>
       </g>
     </svg>

--- a/app/views/styleguide/show.html.erb
+++ b/app/views/styleguide/show.html.erb
@@ -17,21 +17,6 @@
   </section>
 
   <section class="l-styleguide-section">
-    <h2>Inline callout</h2>
-    <%= render 'shared/inline_callout' %>
-  </section>
-
-  <section class="l-styleguide-section">
-    <h2>Collapsible</h2>
-    <%= render 'shared/collapsible' %>
-  </section>
-
-  <section class="l-styleguide-section">
-    <h2>Next steps</h2>
-    <%= render 'shared/next_steps' %>
-  </section>
-
-  <section class="l-styleguide-section">
     <h2>Article Tiles</h2>
     <%= render 'shared/article_tile' %>
   </section>

--- a/lib/publify_textfilter_answer_reveal.rb
+++ b/lib/publify_textfilter_answer_reveal.rb
@@ -8,9 +8,9 @@ class PublifyApp
 
       def self.help_text
         %{
-You can use the following code to display an inline callout snippet. Example:
+        You can use the following code to display an inline callout snippet. Example:
 
-<hr class="snippet" data-snippet-name="answerreveal" data-snippet-question="[ENTER QUESTION TEXT HERE]" data-snippet-answer="[ENTER ANSWER TEXT HERE]" data-snippet-callout-text="[ENTER CALLOUT TEXT HERE]" data-snippet-callout-url="[ENTER CALLOUT URL HERE]" />
+        <hr class="snippet" data-snippet-name="answerreveal" data-snippet-question="[ENTER QUESTION TEXT HERE]" data-snippet-answer="[ENTER ANSWER TEXT HERE]" data-snippet-callout-text="[ENTER CALLOUT TEXT HERE]" data-snippet-callout-url="[ENTER CALLOUT URL HERE]" />
         }
       end
 
@@ -22,7 +22,7 @@ You can use the following code to display an inline callout snippet. Example:
 
         answer = answer.gsub(/^/,"<p>").gsub(/\\n/,"</p><p>").gsub(/$/, "</p>")
 
-        callout_id = Digest::SHA256.hexdigest answer
+        callout_id = Digest::SHA256.hexdigest(answer)
 
         "<div class=\"collapsible\">
           <h3 class=\"collapsible__heading\">#{question}</h3>
@@ -54,8 +54,6 @@ You can use the following code to display an inline callout snippet. Example:
         new_text = text.gsub(regex) do |match|
           macrofilter(blog,content,attributes_parse($1.to_s),params)
         end
-
-        new_text
       end
     end
   end

--- a/lib/publify_textfilter_answer_reveal.rb
+++ b/lib/publify_textfilter_answer_reveal.rb
@@ -1,0 +1,62 @@
+require 'digest'
+
+class PublifyApp
+  class Textfilter
+    class AnswerReveal < TextFilterPlugin::MacroPost
+      plugin_display_name "Answer Reveal"
+      plugin_description "Insert a answer reveal inline callout"
+
+      def self.help_text
+        %{
+You can use the following code to display an inline callout snippet. Example:
+
+<hr class="snippet" data-snippet-name="answerreveal" data-snippet-question="[ENTER QUESTION TEXT HERE]" data-snippet-answer="[ENTER ANSWER TEXT HERE]" data-snippet-callout-text="[ENTER CALLOUT TEXT HERE]" data-snippet-callout-url="[ENTER CALLOUT URL HERE]" />
+        }
+      end
+
+      def self.macrofilter(_, _, attrib, _)
+        question = attrib['data-snippet-text-question']
+        answer = attrib['data-snippet-text-answer']
+        callout_text = attrib['data-snippet-text-callout']
+        callout_url = attrib['data-snippet-url-callout']
+
+        answer = answer.gsub(/^/,"<p>").gsub(/\\n/,"</p><p>").gsub(/$/, "</p>")
+
+        callout_id = Digest::SHA256.hexdigest answer
+
+        "<div class=\"collapsible\">
+          <h3 class=\"collapsible__heading\">#{question}</h3>
+          <div class=\"collapsible__reveal\" data-dough-collapsable-target=\"answer_reveal_#{callout_id}\">
+            #{answer}
+
+            <hr class=\"snippet\" data-snippet-name=\"inlinecallout\" data-snippet-url=\"#{callout_url}\" data-snippet-text=\"#{callout_text}\" />
+          </div>
+          <div class=\"collapsible__trigger\" data-dough-component=\"Collapsable\" data-dough-collapsable-trigger=\"answer_reveal_#{callout_id}\">
+            <span class=\"collapsible__trigger-text\">Reveal the answer</span>
+            <span class=\"collapsible__trigger-text collapsible__trigger-text--hide\">Hide answer</span>
+            <svg class=\"plus-icon\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" viewBox=\"0 0 80 80\" xml:space=\"preserve\">
+              <g class=\"plus-icon__origin\">
+                <g class=\"plus-icon__lines\">
+                  <circle class=\"plus-icon__circle\" cx=\"40\" cy=\"40\" r=\"40\"/>
+                  <line fill=\"none\" class=\"plus-icon__line\" stroke-width=\"6\" stroke-miterlimit=\"10\" x1=\"40\" y1=\"25\" x2=\"40\" y2=\"55\"/>
+                  <line class=\"plus-icon__line plus-icon__line--horizontal\" fill=\"none\" stroke-width=\"6\" stroke-miterlimit=\"10\" x1=\"25\" y1=\"40\" x2=\"55\" y2=\"40\"/>
+                </g>
+              </g>
+            </svg>
+          </div>
+        </div>"
+      end
+
+      def self.filtertext(blog, content, text, params)
+        filterparams = params[:filterparams]
+        regex = /<hr class="snippet" data-snippet-name="#{short_name}"([ \t][^>]*)?\/>/m
+
+        new_text = text.gsub(regex) do |match|
+          macrofilter(blog,content,attributes_parse($1.to_s),params)
+        end
+
+        new_text
+      end
+    end
+  end
+end


### PR DESCRIPTION
- non-js shows question and answer with no trigger
- trigger uses dough collapse to reveal answer
- transitions on plus icon to convert to minus when open
- overridden styles for call out to MAS green if URL is a MAS one