### PR TITLE
4970/4969 - fixing article layout issues

### DIFF
--- a/app/assets/stylesheets/components/article_body/_article_body.scss
+++ b/app/assets/stylesheets/components/article_body/_article_body.scss
@@ -3,7 +3,6 @@
     @include font-size(22);
     color: $heading-color-primary;
     margin-top: 0;
-    float: left;
   }
 
   p {

--- a/app/assets/stylesheets/layouts/_article.scss
+++ b/app/assets/stylesheets/layouts/_article.scss
@@ -33,6 +33,7 @@
     position: absolute;
     @include column(2);
     top: baseline-unit(-10);
+    left: baseline-unit(15);
     z-index: $z-foreground;
   }
 


### PR DESCRIPTION
- ensuring that article info appears on left side of article
  in firefox (not specifying the left: X causes firefox to render it on the right of the page!)
- fixing issue with first paragraph of text floating
  to the left of the next one

See ticket for more info: https://moneyadviceservice.tpondemand.com/entity/4970
and https://moneyadviceservice.tpondemand.com/entity/4969
