### PR TITLE
Allow staging assets to come from a different directory

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,1 +1,5 @@
 require_relative "production"
+
+Rails.application.configure do
+  config.assets.prefix = "/staging-assets"
+end


### PR DESCRIPTION
Allows us to use the same CDN but use different directories depending on the environment the app is running in.
