### PR TITLE
Max width of a list within an article

### DIFF
--- a/app/assets/stylesheets/layouts/_article.scss
+++ b/app/assets/stylesheets/layouts/_article.scss
@@ -52,7 +52,7 @@
   }
 
   @include respond-to($mq-l) {
-    h1, h2, h3, p {
+    h1, h2, h3, p, ul, ol {
       max-width: 550px;
     }
   }


### PR DESCRIPTION
- added ol and ul to list of items to restrict to 550px on
  'desktop' viewport widths