### PR TITLE
Remove category link on article pages

### DIFF
--- a/app/views/articles/_meta.html.erb
+++ b/app/views/articles/_meta.html.erb
@@ -7,11 +7,6 @@
   </p>
 
   <p class="article-info__content">
-    Category
-    <a class="article-info__link" href="#">Money saving tips</a>
-  </p>
-
-  <p class="article-info__content">
     <time datetime="<%= article.published_at %>"><%= display_date_and_time(article.published_at) %></time>
   </p>
 


### PR DESCRIPTION
The category link is hard coded at the moment, and not required for first release so this removes it.