### PR TITLE
Commenting policy links

### DIFF
--- a/app/assets/stylesheets/components/comments/_comments.scss
+++ b/app/assets/stylesheets/components/comments/_comments.scss
@@ -33,9 +33,9 @@
   @include column(12);
 }
 
-.comment-form__group--author, .comment-form__group--email_address {
-  @include column(12);
-
+.comment-form__group--author,
+.comment-form__group--email_address,
+.comment-form__group--policy {
   @include respond-to($mq-two-col) {
     @include column(8);
     @include push(2);
@@ -56,7 +56,8 @@
 }
 
 .comment-form__group {
-  .comment-form__text-field, .comment-form__text-area {
+  .comment-form__text-field,
+  .comment-form__text-area {
     border-width: 0;
     margin-top: $baseline-unit;
     margin-bottom: $baseline-unit*2;

--- a/app/assets/stylesheets/layouts/_page.scss
+++ b/app/assets/stylesheets/layouts/_page.scss
@@ -1,0 +1,22 @@
+.l-page {
+  @include column(12);
+
+  @include respond-to($mq-xl) {
+    @include column(8);
+    @include push(2);
+  }
+}
+
+.l-page__header {
+  margin-top: baseline-unit(3);
+  @include font-size(36);
+  color: $outer-space;
+
+  @include respond-to($mq-l) {
+    @include font-size(48);
+  }
+}
+
+.l-page__body {
+  @include font-size(18);
+}

--- a/app/views/articles/_comment_form.html.erb
+++ b/app/views/articles/_comment_form.html.erb
@@ -29,7 +29,7 @@
     </div>
 
     <div class="comment-form__group comment-form__group--submit">
-      <%= link_to t('.cancel'), '#' %> <input class="button button--primary comment-form__submit-button" type="submit" value="<%= t('.post_comment') %>">
+      <input class="button button--primary comment-form__submit-button" type="submit" value="<%= t('.post_comment') %>">
     </div>
   </div>
 <% end %>

--- a/app/views/articles/_comment_form.html.erb
+++ b/app/views/articles/_comment_form.html.erb
@@ -24,6 +24,10 @@
       <div class="comment-form__group"><%= raw recaptcha_tags ajax: true %></div>
     <% end %>
 
+    <div class="comment-form__group comment-form__group--policy">
+      <p><%= t(".by_clicking_on") %><a href="/pages/commenting-policy"><%= t(".commenting_policy") %></a></p>
+    </div>
+
     <div class="comment-form__group comment-form__group--submit">
       <%= link_to t('.cancel'), '#' %> <input class="button button--primary comment-form__submit-button" type="submit" value="<%= t('.post_comment') %>">
     </div>

--- a/app/views/articles/read.html.erb
+++ b/app/views/articles/read.html.erb
@@ -37,7 +37,7 @@
         <a id="comments"></a>
 
         <h3 class="comments__headline"><%= t(".what_do_you_think")%></h3>
-        <p class="comments__text"><%= t(".if_you_have_an_opinion") %></p>
+        <p class="comments__text"><%= t(".really_want_to_share_your_views") %> <a href="/pages/commenting-policy"><%= t(".full_commenting_guidelines") %></a></p>
 
         <% if @article.allow_comments? -%>
           <%= render "articles/comment_form" %>

--- a/app/views/articles/view_page.html.erb
+++ b/app/views/articles/view_page.html.erb
@@ -1,3 +1,9 @@
-<h1 class='page-header'><%= link_to_permalink(@page, @page.title) %></h1>
-<%= @page.html %>
+<div class="l-page">
+  <div class="l-constrained">
+    <h1 class="l-page__header"><%= @page.title %></h1>
+    <div class="l-page__body">
+      <%= @page.html %>
+    </div>
+  </div>
+</div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,7 +101,8 @@ en:
       comments: "Comments"
       leave_a_response: "Leave a response"
       what_do_you_think: "What do you think?"
-      if_you_have_an_opinion: "If you have a opinion on this why not share it"
+      really_want_to_share_your_views: "We really want you to share your views, but please remember to be nice ☺<br />Check out our"
+      full_commenting_guidelines: "full commenting guidelines"
       rss_feed: "RSS feed"
       comments_are_disabled: "Comments are disabled"
     comment_form:
@@ -126,6 +127,8 @@ en:
       your_message: "Your message"
       comment_markup_help: "Comment Markup Help"
       preview_comment: "Preview comment"
+      by_clicking_on: "By clicking on 'Post Comment', you're agreeing to our "
+      commenting_policy: "Commenting Policy"
     article_links:
       comments:
         zero: "no comments"


### PR DESCRIPTION
This deals with the following tickets:
#4554 Agree to rules of engagement
https://moneyadviceservice.tpondemand.com/entity/4554
#4186 Rules of engagement around commenting https://moneyadviceservice.tpondemand.com/entity/4186

- Adding text above and near the post button which links to the
commenting policy page
- Added text to the en language file
- Applied basic styling to a non-article page
- /pages/commenting-policy will need to be created in the
  admin for the link to work