### PR TITLE
Remain on the article editing page after saving

### DIFF
--- a/app/controllers/admin/content_controller.rb
+++ b/app/controllers/admin/content_controller.rb
@@ -39,7 +39,7 @@ class Admin::ContentController < Admin::BaseController
 
     if @article.save
       flash[:success] = I18n.t('admin.content.create.success')
-      redirect_to action: 'index'
+      redirect_to action: 'edit', id: @article
     else
       @article.keywords = Tag.collection_to_string @article.tags
       load_resources

--- a/app/controllers/admin/content_controller.rb
+++ b/app/controllers/admin/content_controller.rb
@@ -75,7 +75,7 @@ class Admin::ContentController < Admin::BaseController
         Article.where(parent_id: @article.id).map(&:destroy)
       end
       flash[:success] = I18n.t('admin.content.update.success')
-      redirect_to action: 'index'
+      redirect_to action: 'edit', id: @article
     else
       @article.keywords = Tag.collection_to_string @article.tags
       load_resources

--- a/spec/controllers/admin/content_controller_spec.rb
+++ b/spec/controllers/admin/content_controller_spec.rb
@@ -363,14 +363,15 @@ describe Admin::ContentController, type: :controller do
           expect(@orig.body).not_to eq('update')
         end
 
-        it 'redirects to the index' do
-          expect(response).to redirect_to(action: 'index')
-        end
-
         it 'creates a draft' do
           draft = Article.child_of(@orig.id).first
           expect(draft.parent_id).to eq(@orig.id)
           expect(draft).not_to be_published
+        end
+
+        it 'redirects back to the draft edit page' do
+          draft = Article.child_of(@orig.id).first
+          expect(response).to redirect_to(action: 'edit', id: draft)
         end
       end
     end
@@ -431,7 +432,7 @@ describe Admin::ContentController, type: :controller do
         let!(:article) { create(:article, body: 'another *textile* test', user: user) }
         let!(:body) { 'not the *same* text' }
         before(:each) { put :update, id: article.id, article: { body: body, text_filter: 'textile' } }
-        it { expect(response).to redirect_to(action: 'index') }
+        it { expect(response).to redirect_to(action: 'edit', id: article.id) }
         it { expect(article.reload.text_filter.name).to eq('textile') }
         it { expect(article.reload.body).to eq(body) }
       end

--- a/spec/controllers/admin/content_controller_spec.rb
+++ b/spec/controllers/admin/content_controller_spec.rb
@@ -101,10 +101,10 @@ describe Admin::ContentController, type: :controller do
       end
 
       context 'classic' do
-
+        let(:created_article) { Article.last }
         before(:each) { post :create, article: article_params }
 
-        it { expect(response).to redirect_to(action: :index) }
+        it { expect(response).to redirect_to(action: :edit, id: created_article.id) }
         it { expect(flash[:success]).to eq(I18n.t('admin.content.create.success')) }
 
         it { expect(assigns(:article)).to be_published }


### PR DESCRIPTION
As requested.