### PR TITLE
Provide a minimal JSON feed for the latest articles.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'recaptcha', require: 'recaptcha/rails', branch: 'rails3'
 gem 'carrierwave', '~> 0.10.0'
 gem 'akismet', '~> 1.0'
 gem 'twitter', '~> 5.6.0'
+gem 'jbuilder'
 
 gem 'jquery-rails', '~> 3.1.0'
 gem 'jquery-ui-rails', '~> 5.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,9 @@ GEM
     i18n (0.6.11)
     inflecto (0.0.2)
     ipaddress (0.8.0)
+    jbuilder (2.2.6)
+      activesupport (>= 3.0.0, < 5)
+      multi_json (~> 1.2)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -412,6 +415,7 @@ DEPENDENCIES
   guard-rspec
   guard-rubocop
   htmlentities
+  jbuilder
   jquery-rails (~> 3.1.0)
   jquery-ui-rails (~> 5.0.2)
   jshint_ruby

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -45,6 +45,9 @@ class ArticlesController < ContentController
         auto_discovery_feed(only_path: false)
         render_articles_feed('rss')
       end
+      format.json do
+        render_articles_feed('json')
+      end
     end
   end
 

--- a/app/views/articles/index_json_feed.json.jbuilder
+++ b/app/views/articles/index_json_feed.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @articles do |item|
+  json.partial! "shared/json_item_article", {:json => json, :item => item}
+end

--- a/app/views/shared/_json_item_article.json.jbuilder
+++ b/app/views/shared/_json_item_article.json.jbuilder
@@ -1,0 +1,10 @@
+if item.is_a?(Note)
+  json.title truncate(item.html(:body).strip_html, length: 80, separator: ' ', omissions: '...')
+else
+  json.title item.title
+end
+content_html = fetch_html_content_for_feeds(item, this_blog)
+json.description content_html + item.get_rss_description
+json.pubDate item.published_at.rfc822
+
+json.link item.permalink_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   get 'articles.:format', to: 'articles#index', constraints: { format: 'rss' }, as: 'rss'
   get 'articles.:format', to: 'articles#index', constraints: { format: 'atom' }, as: 'atom'
+  get 'articles.:format', to: 'articles#index', constraints: { format: 'json' }, as: 'json'
 
   scope controller: 'xml', path: 'xml' do
     get 'articlerss/:id/feed.xml', action: 'articlerss', format: false

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -215,6 +215,13 @@ describe ArticlesController, 'feeds', type: :controller do
     expect(assigns(:articles)).to eq([article1, article2])
   end
 
+  specify '/articles.json => a JSON serialized object' do
+    get 'index', format: 'json'
+    expect(response).to be_success
+    expect(response).to render_template('index_json_feed', layout: false)
+    expect(assigns(:articles)).to eq([article1, article2])
+  end
+
   specify 'atom feed for archive should be valid' do
     get 'index', year: 2004, month: 4, format: 'atom'
     expect(response).to render_template('index_atom_feed', layout: false)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,6 +110,10 @@ def assert_rss20 feed, count
   expect(root.css('channel item').count).to eq(count)
 end
 
+def assert_json feed, count
+  expect(JSON.parse(feed).count).to eq(count)
+end
+
 def stub_full_article(time = Time.now)
   author = FactoryGirl.build_stubbed(User, name: 'User Name')
   text_filter = FactoryGirl.build(:textile)

--- a/spec/views/articles/index_json_feed_spec.rb
+++ b/spec/views/articles/index_json_feed_spec.rb
@@ -1,0 +1,162 @@
+# coding: utf-8
+describe 'articles/index_json_feed.json.jbuilder', type: :view do
+  let!(:blog) { build_stubbed :blog }
+
+  describe 'rendering articles (with some funny characters)' do
+    before do
+      article1 = stub_full_article(1.minute.ago)
+      article1.body = '&eacute;coute!'
+      article2 = stub_full_article(2.minutes.ago)
+      article2.body = 'is 4 < 2? no!'
+      assign(:articles, [article1, article2])
+      render
+    end
+
+    it 'creates an RSS feed with two items' do
+      assert_json rendered, 2
+    end
+
+    it 'renders the article RSS partial twice' do
+      expect(view).to render_template(partial: 'shared/_json_item_article', count: 2)
+    end
+  end
+
+  describe 'rendering a single article' do
+    before do
+      @article = stub_full_article
+      @article.body = 'public info'
+      @article.extended = 'and more'
+      assign(:articles, [@article])
+    end
+
+    describe 'on a blog that shows extended content in feeds' do
+      before(:each) do
+        Blog.default.hide_extended_on_rss = false
+        render
+      end
+
+      it 'shows the body and extended content in the feed' do
+        expect(rendered_entry["description"]).to match(/public info.*and more/m)
+      end
+    end
+
+    describe 'on a blog that hides extended content in feeds' do
+      before(:each) do
+        Blog.default.hide_extended_on_rss = true
+      end
+
+      it 'shows only the body content in the feed if there is no excerpt' do
+        render
+        entry = rendered_entry
+        expect(entry['description']).to match(/public info/)
+        expect(entry['description']).not_to match(/public info.*and more/m)
+      end
+
+      it 'shows the excerpt instead of the body content in the feed, if there is an excerpt' do
+        @article.excerpt = 'excerpt'
+        render
+        entry = rendered_entry
+        expect(entry['description']).to match(/excerpt/)
+        expect(entry['description']).not_to match(/public info/)
+      end
+    end
+
+    describe 'on a blog that has an RSS description set' do
+      before(:each) do
+        Blog.default.rss_description = true
+        Blog.default.rss_description_text = 'rss description'
+        render
+      end
+
+      it 'shows the body content in the feed' do
+        expect(rendered_entry['description']).to match(/public info/)
+      end
+
+      it 'shows the RSS description in the feed' do
+        expect(rendered_entry['description']).to match(/rss description/)
+      end
+    end
+
+  end
+
+  describe 'rendering a password protected article' do
+    before(:each) do
+      @article = stub_full_article
+      @article.body = "shh .. it's a secret!"
+      @article.extended = 'even more secret!'
+      allow(@article).to receive(:password) { 'password' }
+      assign(:articles, [@article])
+    end
+
+    describe 'on a blog that shows extended content in feeds' do
+      before(:each) do
+        Blog.default.hide_extended_on_rss = false
+        render
+      end
+
+      it 'shows only a link to the article' do
+        expect(rendered_entry['description']).to eq(
+          "<p>This article is password protected. Please <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
+        )
+      end
+
+      it 'does not show any secret bits anywhere' do
+        expect(rendered).not_to match(/secret/)
+      end
+    end
+
+    describe 'on a blog that hides extended content in feeds' do
+      before(:each) do
+        Blog.default.hide_extended_on_rss = true
+        render
+      end
+
+      it 'shows only a link to the article' do
+        expect(rendered_entry['description']).to eq(
+          "<p>This article is password protected. Please <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
+        )
+      end
+
+      it 'does not show any secret bits anywhere' do
+        expect(rendered).not_to match(/secret/)
+      end
+    end
+  end
+
+  describe 'rendering an article with a UTF-8 permalink' do
+    before(:each) do
+      @article = stub_full_article
+      @article.permalink = 'ルビー'
+      assign(:articles, [@article])
+
+      render
+    end
+
+    it 'creates a valid feed' do
+      expect(JSON.parse(rendered)).to be_truthy
+    end
+  end
+
+  def rendered_entry
+    parsed = JSON.parse(rendered)
+    parsed.first
+  end
+
+  describe '#title' do
+    before(:each) do
+      assign(:articles, [article])
+      render
+    end
+
+    context 'with a note' do
+      let(:article) { create(:note) }
+      it { expect(rendered_entry['title']).to eq(article.body) }
+    end
+
+    context 'with an article' do
+      let(:article) { create(:article) }
+      it { expect(rendered_entry['title']).to eq(article.title) }
+    end
+  end
+
+end


### PR DESCRIPTION
Accessible via `/articles.json`

We're using this to provide a "Latest links" section in frontend. We're
using JSON here for reasons of consistency with other MAS projects, e.g.
frontend and contento. Tests are more or less copied and tweaked from
the tests for the RSS feed.

This doesn't contain as much information as /articles.rss, because that
would require a bit more work/testing and it's not required for now.