### PR TITLE
Reworking of article editing

### DIFF
--- a/app/assets/stylesheets/administration_structure.css.scss
+++ b/app/assets/stylesheets/administration_structure.css.scss
@@ -213,6 +213,7 @@ twitter-typeahead {
 
 .save-bar {
   height: 40px;
+  padding-top: 10px;
 }
 
 .gravatar {
@@ -274,4 +275,8 @@ table.possible-related-content {
     width: 150px;
     text-align: center;
   }
+}
+
+#article_title {
+  margin-bottom: 10px;
 }

--- a/app/controllers/admin/content_controller.rb
+++ b/app/controllers/admin/content_controller.rb
@@ -3,7 +3,7 @@ require 'base64'
 module Admin; end
 
 class Admin::ContentController < Admin::BaseController
-  layout :get_layout
+  layout 'administration'
 
   cache_sweeper :blog_sweeper
 
@@ -162,16 +162,5 @@ class Admin::ContentController < Admin::BaseController
 
   def update_params
     params.require(:article).except(:id).permit!
-  end
-
-  def get_layout
-    case action_name
-    when 'new', 'edit', 'create'
-      'editor'
-    when 'show', 'autosave'
-      nil
-    else
-      'administration'
-    end
   end
 end

--- a/app/controllers/admin/content_controller.rb
+++ b/app/controllers/admin/content_controller.rb
@@ -14,7 +14,9 @@ class Admin::ContentController < Admin::BaseController
 
   def index
     @search = params[:search] ? params[:search] : {}
-    @articles = Article.search_with(@search).page(params[:page]).per(this_blog.admin_display_elements)
+    @articles = Article.search_with(@search)
+    @articles = @articles.where('parent_id IS NULL')
+    @articles = @articles.page(params[:page]).per(this_blog.admin_display_elements)
 
     if request.xhr?
       respond_to do |format|

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -59,7 +59,7 @@ class Article < Content
 
   setting :password, :string, ''
 
-  attr_accessor :draft, :keywords
+  attr_accessor :keywords
 
   include Article::States
 

--- a/app/models/article/factory.rb
+++ b/app/models/article/factory.rb
@@ -11,7 +11,6 @@ class Article::Factory
       art.allow_comments = blog.default_allow_comments
       art.allow_pings = blog.default_allow_pings
       art.text_filter = user.default_text_filter
-      art.published = true
     end
   end
 

--- a/app/models/article/states.rb
+++ b/app/models/article/states.rb
@@ -60,6 +60,7 @@ module Article::States
   class Published < Base
     def enter_hook
       super
+      content.just_changed_published_status = true
       content[:published] = true
       content[:published_at] ||= Time.now
     end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -46,7 +46,7 @@ class Content < ActiveRecord::Base
   validates :hero_image_alt_text, presence: true, if: Proc.new { |c| c.hero_image.present? }
   validates :teaser_image_alt_text, presence: true, if: Proc.new { |c| c.teaser_image.present? }
 
-  validates :permalink, uniqueness: true
+  validates :permalink, uniqueness: true, if: :published?
 
   validates :core_content_url, presence: true, if: Proc.new { |c| c.core_content_text.present? }
   validates :core_content_text, presence: true, if: Proc.new { |c| c.core_content_url.present? }

--- a/app/views/admin/content/_article_list.html.erb
+++ b/app/views/admin/content/_article_list.html.erb
@@ -12,6 +12,7 @@
     <%- if article.published %>
       <%= link_to_permalink(article, article.title, nil, 'published')%>
     <%- else %>
+      <strong class="label label-info">Draft:</strong>
       <%= link_to(article.title, {controller: '/articles', action: "preview", id: article.id}, {class: 'unpublished', target: '_new'}) %>
     <%- end %>
     <%= show_actions article %>

--- a/app/views/admin/content/_article_list.html.erb
+++ b/app/views/admin/content/_article_list.html.erb
@@ -12,7 +12,11 @@
     <%- if article.published %>
       <%= link_to_permalink(article, article.title, nil, 'published')%>
     <%- else %>
-      <strong class="label label-info">Draft:</strong>
+      <%- if article.draft? %>
+        <strong class="label label-info">Draft</strong>
+      <%- elsif article.withdrawn? %>
+        <strong class="label label-danger">Withdrawn</strong>
+      <%- end %>
       <%= link_to(article.title, {controller: '/articles', action: "preview", id: article.id}, {class: 'unpublished', target: '_new'}) %>
     <%- end %>
     <%= show_actions article %>

--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -2,22 +2,6 @@
 
 <div id='autosave'><%= hidden_field_tag('article[id]', @article.id) if @article.present? %></div>
 
-<div class='row save-bar'>
-  <div class='col-md-12' id='save-bar'>
-    <div class='pull-right'>
-      <%= link_to(t('.cancel'), {action: 'index'}, {class: 'btn btn-default'}) %>
-      <span id='preview_link'>
-        <%= link_to(t('.preview'), {controller: '/articles', action: 'preview', id: @article.id}, {target: 'new', class: 'btn btn-default'}) if @article.id %>
-      </span>
-      <input id='save_draft' type='submit' value='<%= t('.save_as_draft') %>' name='article[draft]' class='btn btn-default'>
-      <!-- Button trigger modal -->
-      <button class='btn btn-success' data-toggle='modal' data-target='#publishOptions'>
-        <%= ['new', 'create'].include?(controller.action_name) ? t('.publish') : t('.save') %>
-      </button>
-    </div>
-  </div>
-</div>
-
 <div class='row'>
   <div class='col-md-12'>
     <%= text_field 'article', 'title', :class => 'form-control', :placeholder => t('.title') %>
@@ -25,11 +9,13 @@
 </div>
 
 <ul class='nav nav-tabs' role='tablist'>
-  <li role='presentation' class='active'><a href='#main-details' aria-controls='main-details' role='tab' data-toggle='tab'>Article Content</a></li>
+  <li role='presentation' class='active'><a href='#main-details' aria-controls='main-details' role='tab' data-toggle='tab'>Main Content</a></li>
   <li role='presentation'><a href='#images' aria-controls='images' role='tab' data-toggle='tab'>Images</a></li>
   <li role='presentation'><a href='#seo' aria-controls='seo' role='tab' data-toggle='tab'>SEO</a></li>
   <li role='presentation'><a href='#core-content' aria-controls='core-content' role='tab' data-toggle='tab'>Core Content</a></li>
   <li role='presentation'><a href='#related-content' aria-controls='related-content' role='tab' data-toggle='tab'>Related Blog Posts</a></li>
+  <li role='presentation'><a href='#tags' aria-controls='tags' role='tab' data-toggle='tab'>Tags</a></li>
+  <li role='presentation'><a href='#settings' aria-controls='settings' role='tab' data-toggle='tab'>Settings</a></li>
 </ul>
 
 <div class='article-tab-content tab-content'>
@@ -97,6 +83,8 @@
   <div role='tabpanel' class='tab-pane' id='seo'>
     <div class='row article-seo'>
       <div class='col-md-6'>
+        <label for="article_permalink"><%= t('.permalink') %></label>
+        <%= text_field 'article', 'permalink', :autocomplete => 'off', :class => 'form-control' %>
         <label for='article_title_meta_tag'>Page Title (leave empty to use the article's title)</label>
         <%= text_field 'article', 'title_meta_tag', class: 'form-control' %>
         <label for='article_description_meta_tag'>Meta Description</label>
@@ -143,6 +131,81 @@
       </div>
     </div>
   </div>
+  <div role='tabpanel' class='tab-pane' id='tags'>
+    <div class='row'>
+      <div class='col-md-12'>
+        <h4><%= t('.tags') %></h4>
+        <div class='form-group'>
+          <%= text_field 'article', 'keywords', {:autocomplete => 'off', :class => 'form-control tm-input'} %>
+        </div>
+        <p class='alert alert-warning' id='tag-help-text'><%=t('.tags_explaination') %></p>
+      </div>
+    </div>
+  </div>
+  <div role='tabpanel' class='tab-pane' id='settings'>
+    <div class='row'>
+      <div class='col-md-12'>
+        <%- if @post_types.blank? %>
+          <%= hidden_field_tag 'article[post_type]', 'read' %>
+        <%- else %>
+            <div class='col-md-6'>
+              <label for="article_post_type"><%= t('.article_type') %></label>
+              <%= select :article, :post_type, @post_types.map{|pt| [pt.name, pt.permalink]}, {include_blank: t('.default')} %>
+            </div>
+        <%- end %>
+
+        <div class='col-md-6'>
+          <div class="form-row">
+            <label for="article_published_at"><%= t('.published') %></label>
+            <%= text_field 'article', 'published_at', :class => 'form-control' %>
+            <small><%= t('.publish_at_note') %></small>
+          </div>
+          <div class="form-row">
+            <%= check_box 'article', 'allow_pings' %>
+            <label for="article_allow_pings"><%= t('.allow_trackbacks') %></label>
+          </div>
+          <div class="form-row">
+            <%= check_box 'article', 'allow_comments' %>
+            <label for="article_allow_comments"><%= t('.allow_comments') %></label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class='row save-bar'>
+  <div class='col-md-12' id='save-bar'>
+    <% if @article.new_record? || @article.draft? %>
+      <% if @article.new_record? %>
+        <% draft_button_text = t('.save_as_draft') %>
+      <% else %>
+        <% draft_button_text = t('.update_draft') %>
+      <% end %>
+
+      <input id='save_draft' type='submit' value='<%= draft_button_text %>' name='draft' class='btn btn-default'>
+    <% end %>
+
+    <% if @article.new_record? %>
+      <% publish_button_text = t('.publish') %>
+    <% else %>
+      <% if @article.draft? %>
+        <% publish_button_text = t('.publish_draft') %>
+      <% else %>
+        <% publish_button_text = t('.update_published') %>
+      <% end %>
+    <% end %>
+    <input id='save_and_publish' type='submit' value='<%= publish_button_text %>' class='btn btn-default'>
+
+    <% if !@article.new_record? %>
+      or
+      <% if @article.draft? %>
+        <%= link_to t('.preview'), { controller: '/articles', action: 'preview', id: @article.id }, target: 'blank' %>
+      <% else %>
+        <%= link_to t('.view'), @article.permalink_url, target: 'blank' %>
+      <% end %>
+    <% end %>
+  </div>
 </div>
 
 <div class="modal fade" id="inlineCallout" tabindex="-1" role="dialog" aria-labelledby="maSays" aria-hidden="true">
@@ -158,7 +221,7 @@
         </pre>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('.cancel') %></button>
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('.close_modal') %></button>
       </div>
     </div>
   </div>
@@ -177,136 +240,8 @@
         </pre>
       </div>
       <div class='modal-footer'>
-        <button type='button' class='btn btn-default' data-dismiss='modal'><%= t('.cancel') %></button>
+        <button type='button' class='btn btn-default' data-dismiss='modal'><%= t('.close_modal') %></button>
       </div>
     </div>
   </div>
 </div>
-
-<!-- Modal -->
-<div class='modal fade' id='publishOptions' tabindex='-1' role='dialog' aria-labelledby='publishOptions' aria-hidden='true'>
-  <div class='modal-dialog'>
-    <div class='modal-content'>
-      <div class='modal-header'>
-        <h2 class='modal-title' id='myModalLabel'><%= t('.publish') %>
-        <%= submit_tag(t('.publish'), :class => 'btn btn-success pull-right') %>&nbsp;
-        </h2>
-      </div>
-      <div class='modal-body'>
-        <div class='well'>
-          <h4><%= t('.tags') %></h4>
-          <div class='form-group'>
-            <%= text_field 'article', 'keywords', {:autocomplete => 'off', :class => 'form-control tm-input'} %>
-          </div>
-          <p class='alert alert-warning' id='tag-help-text'><%=t('.tags_explaination') %></p>
-        </div>
-        <% post_types = @post_types || [] %>
-        <%- if post_types.size.zero? %>
-          <%= hidden_field_tag 'article[post_type]', 'read' %>
-      <%- else %>
-          <div class='well'>
-          <h4><%= t('.article_type') %></h4>
-          <%= select :article, :post_type, post_types.map{|pt| [pt.name, pt.permalink]}, {include_blank: t('.default')} %>
-        </div>
-      <%- end %>
-
-        <!-- Start of publish settings -->
-        <div class='well'>
-          <fieldset>
-            <legend><%= t('.publish_settings') %></legend>
-            <!-- Start of permalink box -->
-            <div class='control-group'>
-              <p>
-              <%= t('.permalink') %>:
-              <%= toggle_element('permalink') %>
-              </p>
-              <div id='permalink' class='collapse'>
-                <div class='form-group'>
-                  <%= text_field 'article', 'permalink', {:autocomplete => 'off', :class => 'form-control'} %>
-                </div>
-                <p>
-                <span class='btn btn-mini btn-default'>
-                  <%= toggle_element('permalink', t('.ok')) %>
-                </span>
-                </p>
-              </div>
-            </div>
-            <!-- End of permalink box -->
-            <!-- Start of status -->
-            <div class='control-group'>
-              <p>
-              <%= t('.status') %>: <strong><%= @article.state.to_s.downcase %></strong>
-              <%= toggle_element('status') %>
-              </p>
-              <div id='status' class='collapse'>
-                <label for='article_published' class='checkbox'>
-                  <%= check_box 'article', 'published'  %>
-                  <%= t('.published') %>
-                </label>
-                <p>
-                <span class='btn btn-mini btn-default'>
-                  <%= toggle_element('status', t('.ok')) %>
-                </span>
-                </p>
-              </div>
-            </div>
-            <!-- End of status -->
-
-            <!-- Start of feedback settings -->
-            <div class='control-group'>
-              <p>
-              <%= t('.allowed_comments_and_trackbacks', allow_comment: content_tag(:strong, t('.allow_comments_status', count: @article.allow_comments ? 1 : 0)), allow_trackback: content_tag(:strong, t('.allow_pings_status', count: @article.allow_pings ? 1 : 0))) %>
-              <%= toggle_element('conversation') %>
-              </p>
-              <div id='conversation' class='collapse'>
-                <label for='article_allow_pings' class='checkbox'>
-                  <%= check_box 'article', 'allow_pings' %>
-                  <%= t('.allow_trackbacks') %>
-                </label>
-                <label for='article_allow_comments' class='checkbox'>
-                  <%= check_box 'article', 'allow_comments' %>
-                  <%= t('.allow_comments') %>
-                </label>
-                <p>
-                <span class='btn btn-mini btn-default'>
-                  <%= toggle_element('conversation', t('.ok')) %>
-                </span>
-                </p>
-              </div>
-            </div>
-            <!-- End of feedback settings -->
-
-            <!-- Start of date publish -->
-            <div class='control-group'>
-              <p>
-              <%= t('.published') %>
-              <strong>
-                <%- if @article.published %>
-                  <%= display_date_and_time(@article.published_at) %>
-              <%- else %>
-                  <%= t('.now') %>
-              <%- end %>
-              </strong>
-              <%= toggle_element('publish') %>
-              </p>
-              <div id='publish' class='collapse'>
-                <%= text_field 'article', 'published_at' %>
-                <p>
-                <span class='btn btn-mini btn-default'>
-                  <%= toggle_element('publish', t('.ok')) %>
-                </span>
-                </p>
-              </div>
-            </div>
-            <!-- End of date publish -->
-          </fieldset>
-        </div>
-        <!-- End of publish settings -->
-      </div>
-      <div class='modal-footer'>
-        <button type='button' class='btn btn-default' data-dismiss='modal'><%= t('.cancel') %></button>
-        <%= submit_tag(t('.publish'), :class => 'btn btn-success') %>
-      </div>
-    </div><!-- /.modal-content -->
-  </div><!-- /.modal-dialog -->
-</div><!-- /.modal -->

--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -12,7 +12,7 @@
       <input id='save_draft' type='submit' value='<%= t('.save_as_draft') %>' name='article[draft]' class='btn btn-default'>
       <!-- Button trigger modal -->
       <button class='btn btn-success' data-toggle='modal' data-target='#publishOptions'>
-        <%= controller.action_name == 'new' ? t('.publish') : t('.save') %>
+        <%= ['new', 'create'].include?(controller.action_name) ? t('.publish') : t('.save') %>
       </button>
     </div>
   </div>

--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -3,7 +3,7 @@
 <div id='autosave'><%= hidden_field_tag('article[id]', @article.id) if @article.present? %></div>
 
 <div class='row save-bar'>
-  <div class='col-md-8 col-md-offset-2' id='save-bar'>
+  <div class='col-md-12' id='save-bar'>
     <div class='pull-right'>
       <%= link_to(t('.cancel'), {action: 'index'}, {class: 'btn btn-default'}) %>
       <span id='preview_link'>
@@ -19,29 +19,23 @@
 </div>
 
 <div class='row'>
-  <div class='col-md-8 col-md-offset-2' id='error-message-article'>
-    <%= render 'shared/flash', flash: flash %>
-    <%= error_messages_for 'article' %>
-  </div>
-</div>
-
-<ul class='nav nav-tabs' role='tablist'>
-  <li role='presentation' class='active'><a href='#main-details' aria-controls='main-details' role='tab' data-toggle='tab'>Main Details</a></li>
-  <li role='presentation'><a href='#images' aria-controls='images' role='tab' data-toggle='tab'>Images</a></li>
-  <li role='presentation'><a href='#core-content' aria-controls='core-content' role='tab' data-toggle='tab'>Core Content</a></li>
-  <li role='presentation'><a href='#related-content' aria-controls='related-content' role='tab' data-toggle='tab'>Related Blog Posts</a></li>
-</ul>
-
-<div class='row'>
-  <div class='col-md-8'>
+  <div class='col-md-12'>
     <%= text_field 'article', 'title', :class => 'form-control', :placeholder => t('.title') %>
   </div>
 </div>
 
+<ul class='nav nav-tabs' role='tablist'>
+  <li role='presentation' class='active'><a href='#main-details' aria-controls='main-details' role='tab' data-toggle='tab'>Article Content</a></li>
+  <li role='presentation'><a href='#images' aria-controls='images' role='tab' data-toggle='tab'>Images</a></li>
+  <li role='presentation'><a href='#seo' aria-controls='seo' role='tab' data-toggle='tab'>SEO</a></li>
+  <li role='presentation'><a href='#core-content' aria-controls='core-content' role='tab' data-toggle='tab'>Core Content</a></li>
+  <li role='presentation'><a href='#related-content' aria-controls='related-content' role='tab' data-toggle='tab'>Related Blog Posts</a></li>
+</ul>
+
 <div class='article-tab-content tab-content'>
   <div role='tabpanel' class='tab-pane active' id='main-details'>
     <div class='row'>
-      <div class='col-md-8'>
+      <div class='col-md-12'>
         <div id='editor'>
           <%= cktext_area('article', 'body_and_extended', class: 'form-control', placeholder: t('.type_your_post')) %>
         </div> <!-- End of editor -->
@@ -53,32 +47,23 @@
         </div>
       </div>
     </div>
-    <div class='row article-seo'>
-      <div class='col-md-8'>
-        <h3>SEO</h3>
-        <label for='article_title_meta_tag'>Page Title (leave empty to use the article's title)</label>
-        <%= text_field 'article', 'title_meta_tag', class: 'form-control' %>
-        <label for='article_description_meta_tag'>Meta Description</label>
-        <%= text_field 'article', 'description_meta_tag', class: 'form-control' %>
-      </div>
-    </div>
   </div>
   <div role='tabpanel' class='tab-pane' id='images'>
     <div class='article-image-fields'>
       <div class='row'>
-        <div class='col-md-8'>
+        <div class='col-md-6'>
           <h3>Hero Image</h3>
         </div>
       </div>
       <div class='row'>
-        <div class='col-md-4'>
+        <div class='col-md-6'>
           <label for='article_hero_image'>File to Upload</label>
           <%= file_field 'article', 'hero_image', :class => 'form-control' %>
           <%= hidden_field 'article', 'hero_image_cache' %>
           <label for='article_teaser_image_alt_text'>Alt Text</label>
           <%= text_field 'article', 'hero_image_alt_text', :class => 'form-control' %>
         </div>
-        <div class='col-md-4'>
+        <div class='col-md-6'>
           <% if @article.hero_image.present? %>
               <%= image_tag @article.hero_image.url(:resized) %>
               <label><%= check_box 'article', 'remove_hero_image' %> Remove?</label>
@@ -88,19 +73,19 @@
     </div>
     <div class='article-image-fields'>
       <div class='row'>
-        <div class='col-md-8'>
+        <div class='col-md-12'>
           <h3>Teaser Image</h3>
         </div>
       </div>
       <div class='row'>
-        <div class='col-md-4'>
+        <div class='col-md-6'>
           <label for='article_teaser_image'>File to Upload</label>
           <%= file_field 'article', 'teaser_image', :class => 'form-control' %>
           <%= hidden_field 'article', 'teaser_image_cache' %>
           <label for='article_teaser_image_alt_text'>Alt Text</label>
           <%= text_field 'article', 'teaser_image_alt_text', :class => 'form-control' %>
         </div>
-        <div class='col-md-4'>
+        <div class='col-md-6'>
           <% if @article.teaser_image.present? %>
               <%= image_tag @article.teaser_image.url(:resized) %>
               <label><%= check_box 'article', 'remove_teaser_image' %> Remove?</label>
@@ -109,9 +94,19 @@
       </div>
     </div>
   </div>
+  <div role='tabpanel' class='tab-pane' id='seo'>
+    <div class='row article-seo'>
+      <div class='col-md-6'>
+        <label for='article_title_meta_tag'>Page Title (leave empty to use the article's title)</label>
+        <%= text_field 'article', 'title_meta_tag', class: 'form-control' %>
+        <label for='article_description_meta_tag'>Meta Description</label>
+        <%= text_field 'article', 'description_meta_tag', class: 'form-control' %>
+      </div>
+    </div>
+  </div>
   <div role='tabpanel' class='tab-pane' id='core-content'>
     <div class='row article-core-content'>
-      <div class='col-md-8'>
+      <div class='col-md-12'>
         <p>Either complete both, or leave both empty.</p>
         <label for='article_core_content_text'>Text</label>
         <%= text_field 'article', 'core_content_text', class: 'form-control' %>

--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -186,20 +186,26 @@
       <input id='save_draft' type='submit' value='<%= draft_button_text %>' name='draft' class='btn btn-default'>
     <% end %>
 
+    <% if @article.published? %>
+      <input id='save_and_withdraw' type='submit' value='<%= t('.withdraw') %>' name='withdraw' class='btn btn-default'>
+    <% end %>
+
     <% if @article.new_record? %>
       <% publish_button_text = t('.publish') %>
     <% else %>
       <% if @article.draft? %>
         <% publish_button_text = t('.publish_draft') %>
-      <% else %>
+      <% elsif @article.published? %>
         <% publish_button_text = t('.update_published') %>
+      <% elsif @article.withdrawn? %>
+        <% publish_button_text = t('.reinstate_withdrawn') %>
       <% end %>
     <% end %>
     <input id='save_and_publish' type='submit' value='<%= publish_button_text %>' class='btn btn-default'>
 
     <% if !@article.new_record? %>
       or
-      <% if @article.draft? %>
+      <% if @article.draft? || @article.withdrawn? %>
         <%= link_to t('.preview'), { controller: '/articles', action: 'preview', id: @article.id }, target: 'blank' %>
       <% else %>
         <%= link_to t('.view'), @article.permalink_url, target: 'blank' %>

--- a/app/views/admin/content/index.html.erb
+++ b/app/views/admin/content/index.html.erb
@@ -6,25 +6,20 @@
 </h2>
 <% end %>
 
-<%= form_tag({action: 'index'}, {method: :get, name: 'article', remote: true, :class => 'form-inline spinnable', :"data-update-success" => 'articleList'}) do %>
+<%= form_tag({action: 'index'}, {method: :get, name: 'article', :class => 'form-inline spinnable', :"data-update-success" => 'articleList'}) do %>
 
   <% if params[:search] and params[:search]['state'] %>
     <input type='hidden' name="search[state]" value="<%= params[:search]['state'] %>" >
   <% end %>
-  
-  <p>
-    <%= link_to(t(".all_articles"), {action: 'index'}, {class: 'label label-default'}) %>
-    <%= link_to(t(".published"), {action: 'index', search: {state: 'published'}}, {class: 'label label-success'}) %>
-    <%= link_to(t(".withdrawn"), {action: 'index', search: {state: 'withdrawn'}}, {class: 'label label-danger'}) %>
-    <%= link_to(t(".drafts"), {action: 'index', search: {state: 'drafts'}}, {class: 'label label-info'}) %>
-    <%= link_to(t(".publication_pending"), {action: 'index', search: {state: 'pending'}}, {class: 'label label-warning'}) %>
-  </p>
   
   <div class="panel panel-default">
     <div class="panel-heading">
       <div class='pull-right'>
         <div class='form-group'>
           <%= select_tag('search[user_id]', options_from_collection_for_select(User.all, 'id', 'name'), {prompt: t(".select_an_author"), :class => 'form-control'}) %>
+        </div>
+        <div class='form-group'>
+          <%= select_tag('search[state]', options_for_select([['Draft', 'drafts'], ['Published', 'published'], ['Withdrawn', 'withdrawn']], params[:search].try(:[], :state)), {prompt: t(".any_state"), :class => 'form-control'}) %>
         </div>
         <div class='form-group'>
           <%= select_tag('search[published_at]', options_for_select(Article.find_by_published_at), {prompt: t(".publication_date"), :class => 'form-control'}) %>  

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -698,9 +698,14 @@ en:
         latest_comments: "Latest Comments"
     content:
       create:
-        success: "Article was successfully created"
+        success:
+          draft: "Draft article successfully created"
+          published: "Article successfully created and published"
       update:
-        success: "Article was successfully updated"
+        success:
+          draft: "Draft article succesfully updated"
+          published: "Draft article successfully published"
+          published_updated: "Published article was successfully updated"
       access_granted:
         error: "Error, you are not allowed to perform this action"
       autosave:
@@ -724,8 +729,13 @@ en:
       form:
         article_type: "Article type"
         now: "now"
-        preview: "Preview"
-        save: "Save"
+        preview: "preview this article"
+        view: "view live article"
+        save_as_draft: "Save as draft"
+        update_draft: "Update draft"
+        publish: "Publish"
+        update_published: "Update published article"
+        publish_draft: "Publish draft"
         default: "Default"
         cancel: "Cancel"
         allow_comments_status:
@@ -735,26 +745,26 @@ en:
           zero: "disabled"
           one: "enabled"
         public: "Public"
-        publish: "Publish"
         title: "Title"
         images: "Images"
         publish_settings: "Publish settings"
         status: "Status"
-        published: "Published"
+        published: "Published at Timestamp (for display and sorting)"
         allowed_comments_and_trackbacks: "Comments are %{allow_comment} and trackbacks are %{allow_trackback}"
         change: "Change"
+        publish_at_note: "If left blank, populates automatically with the current time when publishing"
         allow_trackbacks: "Allow trackbacks"
         allow_comments: "Allow comments"
         ok: "OK"
         visibility: "Visibility"
         password: "Password"
-        permalink: "Permalink"
+        permalink: "Permalink (URL Slug)"
         article_filter: "Article filter"
-        save_as_draft: "Save as draft"
         categories: "Categories"
         tags: "Tags"
         tags_explaination: "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;."
         type_your_post: "Type your post"
+        close_modal: "Close"
       categories:
         new_category: "New Category"
     categories:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -717,6 +717,7 @@ en:
       index:
         published: "Published"
         new_article: "New article"
+        any_state: "Any state"
         all_articles: "All articles"
         manage_articles: "Manage articles"
         withdrawn: "Withdrawn"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -706,6 +706,8 @@ en:
           draft: "Draft article succesfully updated"
           published: "Draft article successfully published"
           published_updated: "Published article was successfully updated"
+          published_withdrawn: "Withdrawn article was successfully republished and is now visible to visitors"
+          withdrawn: "Published article was successfully withdrawn and is no longer visible to visitors"
       access_granted:
         error: "Error, you are not allowed to perform this action"
       autosave:
@@ -736,6 +738,8 @@ en:
         publish: "Publish"
         update_published: "Update published article"
         publish_draft: "Publish draft"
+        withdraw: "Withdraw"
+        reinstate_withdrawn: "Reinstate withdrawn article"
         default: "Default"
         cancel: "Cancel"
         allow_comments_status:

--- a/spec/controllers/admin/content_controller_spec.rb
+++ b/spec/controllers/admin/content_controller_spec.rb
@@ -280,6 +280,34 @@ describe Admin::ContentController, type: :controller do
           end
         end
       end
+
+      describe 'withdrawing a published article' do
+        before do
+          put(:update,
+              id: @article.id,
+              article: { id: @article.id },
+              withdraw: '')
+          @article.reload
+        end
+
+        it 'sets the published flag to false' do
+          expect(@article.published).to be_falsy
+        end
+      end
+
+      describe 'reinstating a withdrawn article' do
+        before do
+          @article.update_attribute(:state, 'withdrawn')
+          put(:update,
+              id: @article.id,
+              article: { id: @article.id })
+          @article.reload
+        end
+
+        it 'sets the published flag to true' do
+          expect(@article.published).to be_truthy
+        end
+      end
     end
 
     describe 'auto_complete_for_article_keywords action' do

--- a/spec/models/article/factory_spec.rb
+++ b/spec/models/article/factory_spec.rb
@@ -9,7 +9,7 @@ describe Article::Builder, type: :model do
     it { expect(new_article.allow_comments).to eq(blog.default_allow_comments) }
     it { expect(new_article.allow_pings).to eq(blog.default_allow_pings) }
     it { expect(new_article.text_filter).to eq(user.default_text_filter) }
-    it { expect(new_article.published).to be_truthy }
+    it { expect(new_article.published).to be_falsy }
   end
 
   describe '#get_or_build' do
@@ -24,7 +24,7 @@ describe Article::Builder, type: :model do
 
       it { expect(new_article).to be_kind_of(Article) }
       it { expect(new_article.id).to be_nil }
-      it { expect(new_article.published).to be_truthy }
+      it { expect(new_article.published).to be_falsy }
       it { expect(new_article.allow_pings).to eq(blog.default_allow_pings) }
       it { expect(new_article.allow_comments).to eq(blog.default_allow_comments) }
       it { expect(new_article.text_filter).to eq(user.default_text_filter) }


### PR DESCRIPTION
- rearrange article editing layout to make better use of space
- reintroduce standard layout, more useful that way and also side steps cancel button confusion
- simpler workflow - draft > published > withdraw > reinstate
- do away with modal publishing window, it simply wasn't properly thought through and the flow didn't work
- redo saving buttons to deal with broken workflow and make more intuitive
- more descriptive flash messages to communicate exactly what's happened on a save
- remove no longer used autosave functionality and with that other now pointless complexity
- some improvements to the article list - clearer identifying of non published article states, better filtering