### PR TITLE
Disable autocomplete on comments

### DIFF
--- a/app/views/articles/_comment_form.html.erb
+++ b/app/views/articles/_comment_form.html.erb
@@ -7,7 +7,7 @@
     <% end %>
 
     <div class="comment-form__group comment-form__group--body">
-      <%= f.text_area :body, :rows => 8, class: 'form-control comment-form__text-area', placeholder: t('.your_comment') %>
+      <%= f.text_area :body, :rows => 8, class: 'form-control comment-form__text-area', placeholder: t('.your_comment'), :autocomplete => "disabled" %>
     </div>
 
     <div class="comment-form__group comment-form__group--author">


### PR DESCRIPTION
Chrome seems to no longer respect `autocomplete="off"` on input fields, and rather only works when set on the whole form tag.

However setting it to a string other than 'off' fixes it.