### PR TITLE
Alternative approach to removing hero and teaser images

### DIFF
--- a/app/controllers/admin/content_controller.rb
+++ b/app/controllers/admin/content_controller.rb
@@ -78,6 +78,21 @@ class Admin::ContentController < Admin::BaseController
       if !params[:draft]
         Article.where(parent_id: @article.id).map(&:destroy)
       end
+
+      # When trying to use the standard carrierwave methods to remove attachments, something
+      # is causing it to try to remove items from the cdn twice.  The following approach works
+      # around this by removing the image from the cdn manually, then updating the column without
+      # triggering any callbacks (which is where the extra cdn call seems to come from).
+      if params[:remove_hero_image]
+        @article.hero_image.remove!
+        @article.update_column(:hero_image, nil)
+      end
+
+      if params[:remove_teaser_image]
+        @article.teaser_image.remove!
+        @article.update_column(:teaser_image, nil)
+      end
+
       if @article.draft?
         flash[:success] = I18n.t('admin.content.update.success.draft')
       elsif @article.withdrawn?

--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -60,7 +60,7 @@
         <div class='col-md-6'>
           <% if @article.hero_image.present? %>
               <%= image_tag @article.hero_image.url(:resized) %>
-              <label><%= check_box 'article', 'remove_hero_image' %> Remove?</label>
+              <label><%= check_box_tag :remove_hero_image %> Remove?</label>
           <% end %>
         </div>
       </div>
@@ -82,7 +82,7 @@
         <div class='col-md-6'>
           <% if @article.teaser_image.present? %>
               <%= image_tag @article.teaser_image.url(:resized) %>
-              <label><%= check_box 'article', 'remove_teaser_image' %> Remove?</label>
+              <label><%= check_box_tag :remove_teaser_image %> Remove?</label>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
So, this is a bit of a bodge but I've not been able to nail the root cause of this issue.

Basically what's happening is that when you try to use the standard carrierwave functionality to remove an image, it attempts the removal of the images from the cdn twice.  It seems to be something within the callback chain as you're able to call ``remove_hero_image!`` and remove the image, but then when you try to save the record to update the column content, it tries to do the removal again.

So what this does is simply perform the image removal then uses ``update_column`` to perform the update without triggering any callbacks.

It's not pretty but it does the job.