### PR TITLE
hide zero comments on tiles

### DIFF
--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -6,6 +6,6 @@
     <h2><%= link_to truncate(article.title, length: 53), article.permalink_url, { :class => 'article-tile__heading article-tile__heading--' + class_name, :title => article.title } %></h2>
 
     <time class="article-tile__date article-tile__date--<%= class_name %>"><%= display_article_date(article) %></time>
-    <%= link_to_permalink(article, article.published_comments.size, 'comments', 'article-tile__comments article-tile__comments--' + class_name) %>
+    <%= link_to_permalink(article, article.published_comments.size, 'comments', 'article-tile__comments article-tile__comments--' + class_name) if article.published_comments.size > 0 %>
   </div>
 </div>


### PR DESCRIPTION
Based on Feedback from Jade, she requested that we removed the speech bubble where there are no comments