### PR TITLE
blog title in header

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -39,14 +39,10 @@
       <div class="l-header-logo">
         <%= render 'shared/beta_logo' %>
         <% if use_custom_header? %>
-          <h1 class="l-header-logo__title">
+          <h1 class="l-header-logo__title">Your Money Advice</h1>
         <% else %>
           <span class="l-header-logo__title">
-        <% end %>
-          <a href="/" class="l-header-title__link">Your Money Advice</a>
-        <% if use_custom_header? %>
-          </h1>
-        <% else %>
+            <a href="/" class="l-header-title__link">Your Money Advice <span class="visually-hidden">home page</span></a>
           </span>
         <% end %>
       </div>


### PR DESCRIPTION
- only have link around blog title when you're not on homepage
- added off screen text to indicate its a link to the homepage