### PR TITLE
stop main tag from showing blue focus box

### DIFF
--- a/app/assets/stylesheets/components/skip_to_link/_skip_to_link.scss
+++ b/app/assets/stylesheets/components/skip_to_link/_skip_to_link.scss
@@ -12,3 +12,7 @@
     top: 0;
   }
 }
+
+main[tabindex="-1"] {
+  outline: 0;
+}


### PR DESCRIPTION
After merging in the skip to content link, the main tag on each page when clicked on can result in a blue outline