### PR TITLE
adding option to make homepage image full bleed

### DIFF
--- a/app/assets/stylesheets/layouts/_campaigns.scss
+++ b/app/assets/stylesheets/layouts/_campaigns.scss
@@ -3,18 +3,47 @@
   background: $white;
 }
 
+.l-campaign--fullbleed {
+  background: $concrete;
+  position: relative;
+
+  .l-constrained {
+    position: relative;
+    margin-top: baseline_unit(-4);
+
+    @include respond-to($mq-m) {
+      margin-top: -60px;
+    }
+
+    @include respond-to($mq-l) {
+      margin-top: -105px;
+    }
+  }
+}
+
 .l-campaigns__hero {
+  position: relative;
+
+  img {
+    width: 100%;
+  }
+}
+
+.l-campaign__hero--restrict {
   @include column(12);
   background: $white;
   height: 0;
   padding-bottom: 32.7288%;
-  position: relative;
 }
 
 .l-campaigns__panel {
   background: $gallery;
   overflow: hidden;
   @include column(12);
+
+  .l-campaign--fullbleed & {
+    background: $white;
+  }
 }
 
 .l-campaigns__intro,

--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -43,7 +43,7 @@ class Admin::CampaignsController < ApplicationController
   private
 
   def campaign_params
-    params.require(:campaign).permit(:title, :description, :hero_image, :hero_image_alt_text, :active, :hero_image_cache,
+    params.require(:campaign).permit(:title, :description, :hero_image, :hero_image_alt_text, :active, :hero_image_cache, :full_bleed,
                   primary_link_attributes: [:link_type, :title, :url, :id, :campaign_id],
                   secondary_link_attributes: [:link_type, :title, :url, :id, :campaign_id] )
   end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -9,6 +9,8 @@ class Campaign < ActiveRecord::Base
 
   validates :title, presence: true, length: { maximum: 35 }
   validates :description, presence: true, length: { maximum: 187 }
+  validates :hero_image, presence: true
+  validates :hero_image_alt_text, presence: true
 
   before_save :disable_other_campaigns
 

--- a/app/views/admin/campaigns/_form.html.erb
+++ b/app/views/admin/campaigns/_form.html.erb
@@ -24,6 +24,10 @@
     <p class="help-block">Recommended size: 1440x480</p>
   </div>
   <div class="form-group">
+    <%= f.check_box(:full_bleed) %>
+    <%= label_tag(:full_bleed, "Full Bleed Image?") %>
+  </div>
+  <div class="form-group">
     <%= f.label :hero_image_alt_text %>
     <%= f.text_field :hero_image_alt_text, class: 'form-control', placeholder: 'Alt text for the image' %>
   </div>

--- a/app/views/shared/_campaigns.html.erb
+++ b/app/views/shared/_campaigns.html.erb
@@ -1,10 +1,19 @@
-<div class="l-campaigns">
-  <div class="l-constrained">
+<div class="l-campaigns<%=  @lead_campaign.full_bleed ? ' l-campaign--fullbleed' : '' %>">
+  <% if @lead_campaign.full_bleed %>
     <div class="l-campaigns__hero">
       <% if @lead_campaign.hero_image.present? %>
         <%= image_tag @lead_campaign.hero_image.url(:resized) %>
       <% end %>
     </div>
+  <% end %>
+  <div class="l-constrained">
+    <% unless @lead_campaign.full_bleed %>
+      <div class="l-campaigns__hero l-campaign__hero--restrict">
+        <% if @lead_campaign.hero_image.present? %>
+          <%= image_tag @lead_campaign.hero_image.url(:resized) %>
+        <% end %>
+      </div>
+    <% end %>
     <div class="l-campaigns__panel">
       <div class="l-campaigns__intro">
         <h2 class="l-campaigns__intro__heading"><%= @lead_campaign.title %></h2>

--- a/app/views/shared/_campaigns.html.erb
+++ b/app/views/shared/_campaigns.html.erb
@@ -1,5 +1,5 @@
-<div class="l-campaigns<%=  @lead_campaign.full_bleed ? ' l-campaign--fullbleed' : '' %>">
-  <% if @lead_campaign.full_bleed %>
+<div class="l-campaigns<%= @lead_campaign.full_bleed? ? ' l-campaign--fullbleed' : '' %>">
+  <% if @lead_campaign.full_bleed? %>
     <div class="l-campaigns__hero">
       <% if @lead_campaign.hero_image.present? %>
         <%= image_tag @lead_campaign.hero_image.url(:resized) %>
@@ -7,7 +7,7 @@
     </div>
   <% end %>
   <div class="l-constrained">
-    <% unless @lead_campaign.full_bleed %>
+    <% unless @lead_campaign.full_bleed? %>
       <div class="l-campaigns__hero l-campaign__hero--restrict">
         <% if @lead_campaign.hero_image.present? %>
           <%= image_tag @lead_campaign.hero_image.url(:resized) %>

--- a/db/migrate/20150123105303_add_full_bleed_to_campaigns.rb
+++ b/db/migrate/20150123105303_add_full_bleed_to_campaigns.rb
@@ -1,0 +1,5 @@
+class AddFullBleedToCampaigns < ActiveRecord::Migration
+  def change
+    add_column :campaigns, :full_bleed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150112125050) do
+ActiveRecord::Schema.define(version: 20150123105303) do
 
   create_table "articles_tags", id: false, force: true do |t|
     t.integer "article_id"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20150112125050) do
     t.datetime "updated_at"
     t.integer  "primary_link_id"
     t.integer  "secondary_link_id"
+    t.boolean  "full_bleed"
   end
 
   create_table "ckeditor_assets", force: true do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -332,6 +332,8 @@ FactoryGirl.define do
   factory :campaign do
     title 'Save money at the supermarket'
     description 'Going to university is all about having a good time, discovering yourself and making new friends, right? Well, yes but hopefully you will learn a lot and get a good qualification as well.'
+    hero_image Rack::Test::UploadedFile.new((File.join(Rails.root, 'app', 'assets', 'images', 'campaigns-hero-placeholder.png')))
+    hero_image_alt_text 'alt text'
     active false
   end
 

--- a/spec/features/campaign_pages_spec.rb
+++ b/spec/features/campaign_pages_spec.rb
@@ -50,6 +50,9 @@ feature 'Campaigns' do
     new_campaigns_page.campaign_title.set 'Save money at the supermarket'
     new_campaigns_page.description.set 'Going to university is all about having a good time, discovering yourself and making new friends, right?'
     new_campaigns_page.active.set(true)
+    new_campaigns_page.hero_image.set Rails.root + 'app/assets/images/campaigns-hero-placeholder.png'
+    new_campaigns_page.full_bleed.set(true)
+    new_campaigns_page.hero_image_alt_text.set 'alt text'
     new_campaigns_page.primary_link_type.select 'ma says'
     new_campaigns_page.primary_link_title.set 'Smart shopping: simple tips and tricks to save you money'
     new_campaigns_page.primary_link_url.set 'http//www.example.com'

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -15,6 +15,7 @@ describe Campaign, type: :model do
   it { is_expected.to respond_to(:secondary_link) }
   it { is_expected.to respond_to(:hero_image) }
   it { is_expected.to respond_to(:hero_image_alt_text) }
+  it { is_expected.to respond_to(:full_bleed) }
 
   it { is_expected.to be_valid }
 

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -3,6 +3,8 @@ describe Campaign, type: :model do
   let(:campaign) do
     Campaign.new(title: 'Save money at the supermarket',
                  description: 'Going to university is all about having a good time, discovering yourself and making new friends, right? Well, yes but hopefully you will learn a lot and get a good qualification as well.',
+                 hero_image:  File.new(Rails.root + 'app/assets/images/campaigns-hero-placeholder.png'),
+                 hero_image_alt_text: 'alt text',
                  active: true)
   end
 
@@ -40,6 +42,21 @@ describe Campaign, type: :model do
 
     context 'when description is too long' do
       before { campaign.description = "a" * 188  }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when hero image is not present' do
+      before {
+        campaign.remove_hero_image = true
+        campaign.save!
+      }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when hero image alt is not present' do
+      before { campaign.hero_image_alt_text = ""  }
 
       it { is_expected.not_to be_valid }
     end

--- a/spec/support/pages/new_campaigns_page.rb
+++ b/spec/support/pages/new_campaigns_page.rb
@@ -6,6 +6,10 @@ class NewCampaignsPage < SitePrism::Page
   element :description, "#campaign_description"
   element :active, "#campaign_active"
 
+  element :hero_image, "#campaign_hero_image"
+  element :full_bleed, "#campaign_full_bleed"
+  element :hero_image_alt_text, "#campaign_hero_image_alt_text"
+
   element :primary_link_type, "#campaign_primary_link_attributes_link_type"
   element :primary_link_title, "#campaign_primary_link_attributes_title"
   element :primary_link_url, "#campaign_primary_link_attributes_url"


### PR DESCRIPTION
![screen shot 2015-01-23 at 11 46 17](https://cloud.githubusercontent.com/assets/6049076/5874085/8b3bca54-a2f5-11e4-8572-b571501a3d53.png)

- added full_bleed column to campaign table
- enabled checkbox in admin to choose between
  full bleed and non-full bleed (for illustrations)
- altered template and css to enable the toggle
  between the two options