### PR TITLE
fixing issue where yellow tile was appearing on tag pages

### DIFF
--- a/app/assets/stylesheets/components/tiles/_article_tile.scss
+++ b/app/assets/stylesheets/components/tiles/_article_tile.scss
@@ -156,7 +156,7 @@ $less-than-mq-l: ($mq-l) - .01;
     }
   }
 
-  .non-article-page .l-tile:nth-child(3) & { // 3
+  .homepage .l-tile:nth-child(3) & { // 3
     @include article-tile--popular;
   }
 
@@ -204,7 +204,7 @@ $less-than-mq-l: ($mq-l) - .01;
     }
   }
 
-  .non-article-page .l-tile:nth-child(3) & { // 3
+  .homepage .l-tile:nth-child(3) & { // 3
     @include article-tile__heading--popular;
   }
 


### PR DESCRIPTION
Example page where the issue is:

https://blog.moneyadviceservice.org.uk/tag/savings