### PR TITLE
Adding in a title for the tag page

### DIFF
--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -183,7 +183,7 @@
   @include respond-to($mq-m) {
     position: absolute;
     top: 0;
-    left: 31%;
+    left: 35%;
 
     .homepage & {
       left: 0;
@@ -193,11 +193,10 @@
 
   @include respond-to($mq-l) {
     left: 38%;
+  }
 
-    .homepage & {
-      left: 0;
-      position: relative;
-    }
+  @include respond-to($mq-xl) {
+    left: 40%;
   }
 }
 

--- a/app/assets/stylesheets/layouts/_tiles.scss
+++ b/app/assets/stylesheets/layouts/_tiles.scss
@@ -1,6 +1,14 @@
-.l-tiles {
+.l-tiles__inner {
   @include column(12);
-  margin-top: 5px;
+  margin-top: baseline-unit(4);
+
+  .homepage & {
+    margin-top: 5px;
+  }
+
+  @include respond-to($mq-m) {
+    margin-top: baseline-unit(9);
+  }
 
   .flexbox & {
     flex-wrap: wrap;
@@ -10,6 +18,31 @@
       display: flex;
     }
   }
+}
+
+.l-tiles-title {
+  background: $header-bg-color;
+  color: $white;
+  text-transform: uppercase;
+  font-weight: $brand-font-weight;
+  text-align: center;
+  padding-top: baseline-unit(3);
+  padding-bottom: baseline-unit(5);
+
+  @include respond-to($mq-m) {
+    padding-top: baseline-unit(7);
+    padding-bottom: baseline-unit(9);
+  }
+}
+
+.l-tiles-title__header {
+  @include font-size(36);
+  color: $white;
+  font-family: $brand-font-stack;
+  font-weight: $brand-font-weight;
+  padding-bottom: baseline-unit(2);
+  margin-bottom: 0;
+  text-transform: initial;
 }
 
 .l-tile {

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -4,11 +4,13 @@
   <div class="l-index<%= ' l-index--campaign' if @lead_campaign %>">
     <div class="l-constrained">
       <div class="l-tiles">
-        <% @articles.each_with_index do |article, index| %>
-          <%= render 'popular_tags' if index === 2 %>
-          <%= render :partial => 'article', :object => article, :locals => { :index => index } %>
-        <% end %>
-        <%= paginate @articles, views_prefix: 'archives' %>
+        <div class="l-tiles__inner">
+          <% @articles.each_with_index do |article, index| %>
+            <%= render 'popular_tags' if index === 2 %>
+            <%= render partial: 'article', object: article, locals: { index: index } %>
+          <% end %>
+          <%= paginate @articles, views_prefix: 'archives' %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,10 +1,16 @@
 <main id="main" tabindex="-1" class="l-index">
-  <div class="l-constrained">
-    <div class="l-tiles">
-      <% @articles.each_with_index do |article, index| %>
-        <%= render :partial => '/articles/article', :object => article, :locals => { :index => index } %>
-      <% end %>
-      <%= paginate @articles, views_prefix: 'tags' %>
+  <div class="l-tiles">
+    <div class="l-tiles-title">
+      Articles tagged as
+      <h1 class="l-tiles-title__header"><%= @grouping.display_name %></h1>
+    </div>
+    <div class="l-constrained">
+      <div class="l-tiles__inner">
+        <% @articles.each_with_index do |article, index| %>
+          <%= render partial: '/articles/article', object: article, locals: { index: index } %>
+        <% end %>
+        <%= paginate @articles, views_prefix: 'tags' %>
+      </div>
     </div>
   </div>
 </main>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,7 +1,7 @@
 <main id="main" tabindex="-1" class="l-index">
   <div class="l-tiles">
     <div class="l-tiles-title">
-      Articles tagged as
+      <%= t(".articles_tagged_as") %>
       <h1 class="l-tiles-title__header"><%= @grouping.display_name %></h1>
     </div>
     <div class="l-constrained">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,8 @@ en:
       there_is_no_tags: "There is no tag"
       next_page: "Next page"
       previous_page: "Previous page"
+    show:
+      articles_tagged_as: Articles tagged as
   helper:
     at: "at"
   articles:


### PR DESCRIPTION
- adjusting layout of l-tiles so that tag title can sit
  flush underneath header
- adjusted position of header title slightly to look
  better at 720px and at other viewport widths so that
  it sits centrally with the tag title
- ensure that homepage is unaffected by changes above