### PR TITLE
News section

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,6 +80,10 @@ class ApplicationController < ActionController::Base
   helper_method :use_custom_header?
 
   def generate_popular_articles
-    @popular_articles = MostPopularArticle.last || []
+    @popular_articles = if last = MostPopularArticle.last
+      last.articles
+    else
+      []
+    end
   end
 end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,0 +1,7 @@
+class NewsController < ArticlesController
+  def show_article
+    @article = Article.news.find_by(permalink: params[:id])
+    raise ActiveRecord::RecordNotFound unless @article
+    super
+  end
+end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -1,0 +1,5 @@
+module TagHelper
+  def tagged_as_heading
+    t(".#{request.env['PATH_INFO'].split('/')[1]}.articles_tagged_as")
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -57,6 +57,15 @@ class Article < Content
       .limit(5)
   }
 
+  scope :exclude_news, lambda {
+    sub_query = Article.joins(:tags).where(tags: {name: 'news'})
+    where.not(id: sub_query)
+  }
+
+  scope :news, lambda {
+    joins(:tags).where(tags: {name: 'news'})
+  }
+
   setting :password, :string, ''
 
   attr_accessor :keywords

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,11 +2,11 @@
   <div class="l-footer-links">
     <div class="l-constrained">
       <div class="l-footer-links-section">
-        <% unless @popular_articles.articles.empty? %>
+        <% unless @popular_articles.empty? %>
           <h3 class="l-footer-link__header">What's popular</h3>
 
           <ol class="unstyled-list l-footer-link__list">
-            <% @popular_articles.articles.each do |article| %>
+            <% @popular_articles.each do |article| %>
               <li class="l-footer-link__list-item">
                 <%= link_to article.title, article.permalink_url, title: article.title %>
                 <time class="l-footer-link__list-item-time"><%= "#{display_article_date(article)}" %></time>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,7 +1,7 @@
 <main id="main" tabindex="-1" class="l-index">
   <div class="l-tiles">
     <div class="l-tiles-title">
-      <%= t(".articles_tagged_as") %>
+      <%= tagged_as_heading %>
       <h1 class="l-tiles-title__header"><%= @grouping.display_name %></h1>
     </div>
     <div class="l-constrained">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,7 +61,10 @@ en:
       next_page: "Next page"
       previous_page: "Previous page"
     show:
-      articles_tagged_as: Articles tagged as
+      tag:
+        articles_tagged_as: Articles tagged as
+      news:
+        articles_tagged_as: ''
   helper:
     at: "at"
   articles:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
   end
 
   get '/news', to: 'tags#show', defaults: { id: 'news' }
+  get '/news/:id', to: 'news#show_article'
 
   # SetupController
   match '/setup', to: 'setup#index', via: [:get, :post], format: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Rails.application.routes.draw do
     get 'articles/tag', action: 'tag'
   end
 
+  get '/news', to: 'tags#show', defaults: { id: 'news' }
+
   # SetupController
   match '/setup', to: 'setup#index', via: [:get, :post], format: false
 

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -1,0 +1,22 @@
+describe NewsController do
+  before :each do
+    create(:blog)
+  end
+
+  context 'when requesting a news article' do
+    let(:article) { create(:article, keywords: "News") }
+
+    it 'loads the news article' do
+      get :show_article, id: article.permalink
+      expect(assigns(:article)).to eql(article)
+    end
+  end
+
+  context 'when requesting a non news article' do
+    let(:article) { create(:article) }
+
+    it 'does not load the article' do
+      expect{ get :show_article, id: article.permalink }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,11 +1,50 @@
 # coding: utf-8
 describe Article, type: :model do
-
   let!(:blog) { create(:blog) }
 
   it 'test_content_fields' do
     a = Article.new
     assert_equal [:body, :extended], a.content_fields
+  end
+
+  describe '::exclude_news' do
+    context 'when an article is not tagged with news' do
+      let(:subject) { described_class.new(title: 'my article') }
+
+      it 'it is not returned' do
+        subject.save!
+        expect(described_class.exclude_news).to include(subject)
+      end
+    end
+
+    context 'when an article is tagged with news' do
+      let(:subject) { described_class.new(title: 'my news article', keywords: "News,General") }
+
+      it 'it is not returned' do
+        subject.save!
+        expect(described_class.exclude_news).to be_empty
+      end
+    end
+  end
+
+  describe '::news' do
+    context 'when an article is not tagged with news' do
+      let(:subject) { described_class.new(title: 'my article') }
+
+      it 'it is not returned' do
+        subject.save!
+        expect(described_class.news).to be_empty
+      end
+    end
+
+    context 'when an article is tagged with news' do
+      let(:subject) { described_class.new(title: 'my news article', keywords: "News") }
+
+      it 'it is not returned' do
+        subject.save!
+        expect(described_class.news).to include(subject)
+      end
+    end
   end
 
   describe '#permalink_url' do

--- a/spec/requests/slash_news_spec.rb
+++ b/spec/requests/slash_news_spec.rb
@@ -1,0 +1,21 @@
+describe "/news" do
+  before :each do
+    Blog.create!(base_url: "http://localhost:3000")
+    TextFilter.create!(name: 'none', description: 'None', markup: 'none', filters: [], params: {})
+  end
+
+  context 'when there are news articles' do
+    it 'returns news articles' do
+      Article.create!(title: 'my news article', keywords: "News,General", published_at: Time.now)
+      get "/news"
+      expect(response.body).to include("my news article")
+    end
+  end
+
+  context 'when there are no news articles' do
+    it 'redirects to root path' do
+      get "/news"
+      expect(response).to redirect_to("http://localhost:3000")
+    end
+  end
+end

--- a/spec/views/layouts/default_spec.rb
+++ b/spec/views/layouts/default_spec.rb
@@ -1,5 +1,5 @@
 describe "layouts/default.html.erb", :type => :view do
-  let(:popular_articles) { double(:most_popular_article, articles: []) }
+  let(:popular_articles) { double(:most_popular_article, articles: [], empty?: true) }
 
   before(:each) do
     assign(:keywords, ["foo", "bar"])


### PR DESCRIPTION
- Articles tagged as `News` are available at `/news/PERMALINK`
- fix api for popular articles
- `/news` will render the same as `/tag/news`. a redirect was not acceptable