### PR TITLE
reduce unicorns per server

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,6 +1,6 @@
 # https://devcenter.heroku.com/articles/rails-unicorn
 
-worker_processes (ENV["UNICORN_WORKERS"] || 2).to_i
+worker_processes (ENV["UNICORN_WORKERS"] || 1).to_i
 timeout (ENV["UNICORN_TIMEOUT"] || 20).to_i
 preload_app true
 


### PR DESCRIPTION
We have 5 dynos currently with 2 unicorns each. however this is still going into swap as evident on the dashboard

this will reduce to 1 unicorn per box bringing down the total app instances from 10 to 5