### PR TITLE
[DEV APPROVED] #7022 Responsive Videos - Blog

### DIFF
--- a/app/assets/stylesheets/components/mas_video/_all.scss
+++ b/app/assets/stylesheets/components/mas_video/_all.scss
@@ -1,0 +1,1 @@
+@import 'mas_video';

--- a/app/assets/stylesheets/components/mas_video/_mas_video.scss
+++ b/app/assets/stylesheets/components/mas_video/_mas_video.scss
@@ -1,0 +1,20 @@
+.mas-video-container {
+  @include respond-to($mq-l) {
+    max-width: 550px;
+  }
+}
+
+.mas-video {
+  position: relative;
+  padding-bottom: 56.25%;
+  margin-bottom: $baseline-unit*2;
+  height: 0;
+
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -51,6 +51,9 @@
         <div class="article-callout">
           <button class="btn btn-success" data-toggle="modal" data-target="#brightcoveVideo">Brightcove Video</button>
         </div>
+        <div class="article-callout">
+          <button class="btn btn-success" data-toggle="modal" data-target="#youtubeVideo">YouTube Video</button>
+        </div>
       </div>
     </div>
   </div>
@@ -360,14 +363,41 @@
       <div class="modal-body">
         <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button. <b>Note:</b> Replace [BRIGHT_ID] with the ID of video you wish to embed.</p>
         <textarea disabled="true" class="modal-body__code">
-          <iframe src='//players.brightcove.net/3608769895001/b15c0e6a-51da-4bb1-b717-bccae778670d_default/index.html?videoId=[BRIGHT_ID]'
-          frameBorder="0"
-          allowfullscreen=""
-          webkitallowfullscreen=""
-          mozallowfullscreen=""
-          height="315"
-          width="560">
-          </iframe>
+          <div class="mas-video-container">
+            <div class="mas-video">
+              <iframe src='//players.brightcove.net/3608769895001/b15c0e6a-51da-4bb1-b717-bccae778670d_default/index.html?videoId=[BRIGHT_ID]'
+              frameBorder="0"
+              allowfullscreen=""
+              webkitallowfullscreen=""
+              mozallowfullscreen=""
+              height="315"
+              width="560">
+              </iframe>
+            </div>
+          </div>
+        </textarea>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('.close_modal') %></button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="youtubeVideo" tabindex="-1" role="dialog" aria-labelledby="youtubeVideo" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2>Embed YouTube video</h2>
+      </div>
+      <div class="modal-body">
+        <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button. <b>Note:</b> Replace [YOUTUBE_EMBED_CODE] with the embed code of the YouTube Video.</p>
+        <textarea disabled="true" class="modal-body__code">
+          <div class="mas-video-container">
+            <div class="mas-video">
+              [YOUTUBE_EMBED_CODE]
+            </div>
+          </div>
         </textarea>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
## Adding responsive functionality for blog videos

Adding additional CSS to handle responsive video, The classname's are very specific to MAS
`.mas-video-container` and `.mas-video`

Specificity is required as these are also used in webfeeds so a class of .video may not have been suitable as there is a good chance that a partner hosting our content will also have CSS for a class of this name.

As new containers have been added, a youtube snippet option has also been added to the editor as content creators usually paste the embed code straight into the source of the editor, they will now need to copy the snippet into the editor and then paste their embed code within it:

| Button | Snippet |
|----------|------------|
|<img width="406" alt="screen shot 2016-02-12 at 14 32 03" src="https://cloud.githubusercontent.com/assets/13165846/13009670/a9d3c118-d195-11e5-96eb-b36ebb613761.png">|<img width="622" alt="screen shot 2016-02-12 at 14 34 41" src="https://cloud.githubusercontent.com/assets/13165846/13009710/e73273b0-d195-11e5-9de0-24334dded8fb.png">|

There are 2 containers wrapped around the iframe tag because the content within the blog post inside the following tags have a max-width of 550px:

```
.l-article__body h1, .l-article__body h2, .l-article__body h3, .l-article__body p, .l-article__body ul, .l-article__body ol, .l-article__results h1, .l-article__results h2, .l-article__results h3, .l-article__results p, .l-article__results ul, .l-article__results ol
```
So this rule has been applied to the wrapping container `.mas-video-container`
if the max-width attribute was applied directly to the `.mas-video` element, then it all goes wrong!  

### Screenshots:

| Desktop |
|------------|
|<img width="1238" alt="desktop" src="https://cloud.githubusercontent.com/assets/13165846/13009124/8812d4e0-d192-11e5-96f9-8efea91cd11c.png">|

| Tablet | Mobile |
|----------|----------|
|<img width="928" alt="tablet" src="https://cloud.githubusercontent.com/assets/13165846/13009128/8cf757ec-d192-11e5-8789-068f0d957bac.png">|<img width="552" alt="mobile" src="https://cloud.githubusercontent.com/assets/13165846/13009134/9200309c-d192-11e5-8286-2bbe114557ba.png">|

Functionality is the same across YouTube and Brightcove videos