### PR TITLE
Move the precompile and bundle to pre-build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,14 +17,6 @@ cat > public/version <<EOT
 }
 EOT
 
-echo 'Running Bundle package'
-echo '----'
-bundle package --all
-
-echo 'Precompiling assets'
-echo '----'
-RAILS_ENV=production RAILS_GROUPS=assets rake assets:precompile
-
 echo 'Uploading assets'
 echo '----'
 /usr/local/bin/upload-blog-assets.sh $(pwd)/public

--- a/pre-build.sh
+++ b/pre-build.sh
@@ -29,3 +29,12 @@ bundle install
 echo 'Running bowndler'
 echo '-----------------------'
 bowndler update --production --config.interactive=false
+
+echo 'Running Bundle package'
+echo '----'
+bundle package --all
+
+echo 'Precompiling assets'
+echo '----'
+RAILS_ENV=production RAILS_GROUPS=assets rake assets:precompile
+


### PR DESCRIPTION
There was a lot of Go problems when precompiling the assets. The problem that the build and test was running in parallel and they were affecting each other.