### PR TITLE
Patch CKEDITOR application controller to return relative or absolute URL

### DIFF
--- a/app/models/ckeditor/application_controller.rb
+++ b/app/models/ckeditor/application_controller.rb
@@ -1,0 +1,45 @@
+class Ckeditor::ApplicationController < ApplicationController
+  respond_to :html, :json
+  layout 'ckeditor/application'
+
+  before_filter :find_asset, :only => [:destroy]
+  before_filter :ckeditor_authorize!
+  before_filter :authorize_resource
+
+  protected
+
+  def respond_with_asset(asset)
+    file = params[:CKEditor].blank? ? params[:qqfile] : params[:upload]
+    asset.data = Ckeditor::Http.normalize_param(file, request)
+
+    callback = ckeditor_before_create_asset(asset)
+
+    if callback && asset.save
+      body = params[:CKEditor].blank? ? asset.to_json(:only=>[:id, :type]) : %Q"<script type='text/javascript'>
+          window.parent.CKEDITOR.tools.callFunction(#{params[:CKEditorFuncNum]}, '#{asset_url(asset)}');
+        </script>"
+
+      render :text => body
+    else
+      if params[:CKEditor]
+        render :text => %Q"<script type='text/javascript'>
+              window.parent.CKEDITOR.tools.callFunction(#{params[:CKEditorFuncNum]}, null, '#{Ckeditor::Utils.escape_single_quotes(asset.errors.full_messages.first)}');
+            </script>"
+      else
+        render :nothing => true
+      end
+    end
+  end
+
+  private
+
+  def asset_url(asset)
+    url = Ckeditor::Utils.escape_single_quotes(asset.url_content)
+
+    if URI(url).relative?
+      "#{config.relative_url_root}#{url}"
+    else
+      url
+    end
+  end
+end


### PR DESCRIPTION
The [application controller](https://github.com/galetahub/ckeditor/blob/d0bc44a6fc9fa67d4b007877688f89e5a0cbf79f/app/controllers/ckeditor/application_controller.rb#L19) at revision [d0bc44a6](https://github.com/galetahub/ckeditor/tree/d0bc44a6fc9fa67d4b007877688f89e5a0cbf79f) of the CKEDITOR that we [currently use](https://github.com/moneyadviceservice/publify/blob/e4ea8bc134c0deaa56feea356651364f489de23f/Gemfile.lock#L3) prepends the `relative_url_root` in its response whether the uploaded asset's URL is relative or not.

This is OK locally but uploading an image to the CDN results in:

![screen shot 2016-05-26 at 10 17 42](https://cloud.githubusercontent.com/assets/966819/15616954/911ffdc0-243e-11e6-8246-a27d2f1ad305.png)

This terrible monkey patch is just a copy of the original controller code with the addition of a private method that checks if the asset's URL is relative or not.

Later versions of CKEDITOR have been refactored ([0ebc23b5](https://github.com/galetahub/ckeditor/commit/0ebc23b5c512b1ceb6de58a2616cacf25ec5c2f6)) and introduce an [AssetResponse](https://github.com/galetahub/ckeditor/blob/0ebc23b5c512b1ceb6de58a2616cacf25ec5c2f6/lib/ckeditor/asset_response.rb) class which still has the same problem but would be cleaner to patch. I am reluctant to upgrade CKEDITOR though. Sorry guys. This is ugly.

:monkey: