### PR TITLE
[DEV APPROVED] 7421 - BUG: blog JSON feed for 'From our blog' section

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,6 @@ group :development, :test do
   gem 'guard-livereload'
   gem 'guard-bundler'
   gem 'guard-rubocop'
-  gem 'spring-commands-rspec'
   gem 'launchy'
   gem 'poltergeist'
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,9 +474,6 @@ GEM
       addressable (~> 2.3.3)
       capybara (>= 2.1, < 3.0)
     slop (3.6.0)
-    spring (1.1.3)
-    spring-commands-rspec (1.0.2)
-      spring (>= 0.9.1)
     sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -596,7 +593,6 @@ DEPENDENCIES
   sass-rails (~> 4.0.3)
   simplecov
   site_prism
-  spring-commands-rspec
   sqlite3
   syslog-logger
   twitter (~> 5.6.0)
@@ -605,5 +601,8 @@ DEPENDENCIES
   uuidtools (~> 2.1.1)
   webpurify
 
+RUBY VERSION
+   ruby 2.2.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.4

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -22,6 +22,7 @@ class ArticlesController < ContentController
       format.html
       format.atom
       format.rss
+      format.json
     end
   end
 

--- a/app/views/articles/index.json.jbuilder
+++ b/app/views/articles/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @articles do |item|
+  json.partial! "shared/json_item_article", {:json => json, :item => item}
+end

--- a/app/views/shared/_json_item_article.json.jbuilder
+++ b/app/views/shared/_json_item_article.json.jbuilder
@@ -1,0 +1,2 @@
+json.title item.title
+json.link article_url(item.permalink)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   get 'articles.:format', to: 'articles#index', constraints: { format: 'rss' }, as: 'rss'
   get 'articles.:format', to: 'articles#index', constraints: { format: 'atom' }, as: 'atom'
+  get 'articles.:format', to: 'articles#index', constraints: { format: 'json' }, as: 'json'
 
   controller 'articles', format: false do
     # Initial search goes to /search?q=foo, subsequent pages go to /search/foo/pages/2


### PR DESCRIPTION
The functionality has been accidentally removed for the blog to produce a JSON feed for the CMS to pick up and send to the frontend for the 'From our blog' section on an article page.

This PR created this functionality again, There is an associated PR for the CMS which addresses the URL change from:

```
blog.moneyadviceservice.org.uk
```
To
```
www.moneyadviceservice.org.uk/blog
```

Related CMS PR
[BUG: Updating Publify API call for new blog url](https://github.com/moneyadviceservice/cms/pull/331)