### PR TITLE
Ensure public/cache has the right ownership in RPM.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,25 @@ version_number=${GO_PIPELINE_LABEL-0}
 revision=`git rev-parse HEAD`
 build_date=`date +'%Y-%m-%d %H:%M %z'`
 
+function create_rails_rpm {
+  service_name="mas-$1"
+  shift
+  version_number=$1
+  shift
+  options="$@"
+  source_dir=$(pwd)
+
+  (
+    cd ..
+    rm -Rf build
+    mkdir -p build/srv build/etc/init.d
+    cp $source_dir/etc/after-install build/
+    cp $source_dir/etc/service-script build/etc/init.d/$service_name
+    rsync -va --exclude='.git*' --include=bin/rails --exclude=bin/* --exclude=features/ --exclude=log/ --exclude=spec/ --exclude=tmp/ $source_dir/ build/srv
+    fpm --after-install build/after-install --version $version_number --name $service_name --prefix=/ -a all -C build -t rpm -s dir $options srv etc
+  )
+}
+
 cat > public/version <<EOT
 {
   "version":"$version_number",
@@ -31,5 +50,8 @@ echo '----'
 
 echo 'Creating RPM'
 echo '----'
-cd ..
-/usr/local/rpm_builder/create-rails-rpm $artifact_name $artifact_name $version_number
+create_rails_rpm $artifact_name $version_number --rpm-attr 0755,mas,service:/srv/blog/public/cache 
+
+
+
+

--- a/etc/after_install
+++ b/etc/after_install
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -x
+mkdir -p /var/log/mas
+exec > /var/log/mas/rpm_builder-after_install-mas-blog 2>&1
+
+. /etc/mas/environment
+
+APP_PATH=/app/blog
+
+GEMSET=`cat $APP_PATH/.ruby-gemset`
+RUBY_VERSION=`cat $APP_PATH/.ruby-version`
+
+RVM="/usr/local/rvm/bin/rvm"
+RVM_STRING="$RUBY_VERSION@$GEMSET"
+
+cd $APP_PATH
+
+$RVM in $APP_PATH do bundle install --without=test development assets --local --frozen --no-cache
+$RVM alias create mas-blog $RVM_STRING --create
+$RVM wrapper mas-blog unicorn_rails
+$RVM wrapper mas-blog unicorn
+
+RAKE="/usr/local/rvm/wrappers/mas-blog/rake"
+
+#Run migrations
+echo "Running $RAKE db:create & db:migrate if it exists"
+$RAKE -T db: | grep "db:" && $RAKE db:create --trace && $RAKE db:migrate --trace

--- a/etc/service-script
+++ b/etc/service-script
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+### BEGIN INIT INFO
+# Provides: Unicorn Service mas-blog
+# Required-Start: $local_fs $remote_fs
+# Required-Stop:
+# X-Start-Before:
+# Default-Start: 2 3 4 5
+# Default-Stop:
+### END INIT INFO
+#chkconfig: 2345 95 50
+#description: Starts Service mas-blog
+
+set -e
+
+APP_NAME=blog
+APP_PATH=/app/$APP_NAME
+SERVICE_NAME=mas-$APP_NAME
+
+. /etc/mas/environment
+. /etc/sysconfig/$SERVICE_NAME
+
+APP_PORT=${APP_PORT-3000}
+STATUS_URL=${STATUS_URL-http://localhost:$APP_PORT/blog}
+PID_FILE=${PID_FILE-/var/run/$SERVICE_NAME.pid}
+OLD_PID_FILE="$PID_FILE.oldbin"
+CONF_FILE=${CONF_FILE-/etc/mas/$APP_NAME/unicorn.conf}
+TIMEOUT=${TIMEOUT-60}
+
+sig () {
+  test -s "$PID_FILE" && kill -$1 `cat $PID_FILE`
+}
+
+oldsig () {
+  test -s $OLD_PID_FILE && kill -$1 `cat $OLD_PID_FILE`
+}
+
+start() {
+  cd $APP_PATH && /usr/local/rvm/wrappers/$SERVICE_NAME/unicorn -D -E production -c $CONF_FILE &
+  server_down=1
+  attempts=12
+  while [[ "$server_down" -eq "1" && $attempts -gt 0 ]] ; do
+    sleep 5
+    echo "Checking url "$STATUS_URL" after waiting 5 seconds: Attempts Left: $attempts"
+    (curl -sI -m 4 "$STATUS_URL" | grep "200 OK") && server_down=0
+    attempts=`expr $attempts - 1` || true # don't blow up when result is 0
+  done
+  if [ "$server_down" -eq "1" ]
+  then
+    echo "Service $SERVICE_NAME did not startup !!"
+    exit 1
+  else
+    echo "Service $SERVICE_NAME started"
+  fi
+}
+
+restart() {
+  echo "Upgrading $SERVICE_NAME"
+  if sig USR2 && sleep 2 && sig 0 && oldsig QUIT
+  then
+    n=$TIMEOUT
+    while test -s $OLD_PID_FILE && test $n -ge 0
+    do
+      printf '.' && sleep 1 && n=$(( $n - 1 ))
+    done
+    echo
+
+    if test $n -lt 0 && test -s $OLD_PID_FILE
+    then
+      echo "$OLD_PID_FILE still exists after $TIMEOUT seconds"
+      exit 1
+    fi
+    exit 0
+  fi
+  echo "Couldn't upgrade, stopping and starting instead"
+  stop
+  start
+}
+
+status() {
+  pgrep -f $CONF_FILE
+  if [ $? -eq 0 ]; then
+    echo "Service $SERVICE_NAME is running"
+  else
+    echo "Service $SERVICE_NAME is stopped"
+    exit 2
+  fi
+}
+
+stop() {
+  [ -s $PID_FILE ] && (kill -QUIT $(cat $PID_FILE) || true)
+  pgrep -f $CONF_FILE
+  if [ $? -eq 0 ]; then
+    echo "Service $SERVICE_NAME failed to stop, manually killing"
+    pgrep -f $CONF_FILE | xargs kill -9
+  else
+    echo "Service $SERVICE_NAME is stopped"
+  fi
+}
+
+
+case $1 in
+start)
+  start
+  ;;
+
+restart)
+  restart
+  ;;
+
+status)
+  status
+  ;;
+
+stop)
+  stop
+  ;;
+esac


### PR DESCRIPTION
This has been hard to do with the external 'create-rails-rpm' script we
have, so we've added RPM generation to the build.sh script here.

The whole complication of having the external tool `create-rails-rpm` which is in a repo `rpm_builder` which is a sub-module pulled into `scripts` it ... a bit complicated. So this PR is testing out the idea of moving this logic, along with the `after-install` and service start/stop scripts into the application repo. This gives us finer granularity control when it comes to controlling these things, balanced out with more work if we want to fundamentally change how we build RPMs (we'll have to make changes to multiple RPM build scripts).

If this change looks good and once we've proved it works, we should move forward with changing `frontend` and `cms` to build RPMs the same way.