### PR TITLE
Open Graph and Twitter url metatags should be full urls with host

### DIFF
--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -2,7 +2,7 @@
 <%= meta_tag 'og:title', @article ? @article.title : @page_title, true %>
 <% if @article %>
   <%= meta_tag 'og:description', @description %>
-  <%= meta_tag 'og:url', article_path(@article.permalink), true %>
+  <%= meta_tag 'og:url', article_url(@article.permalink), true %>
   <% if @article.hero_image.present? %>
     <%= meta_tag 'og:image', @article.hero_image.url(:resized), true %>
   <% end %>
@@ -12,7 +12,7 @@
 <%= meta_tag 'twitter:card', 'summary_large_image' %>
 <% if @article %>
   <%= meta_tag 'twitter:description', @description %>
-  <%= meta_tag 'twitter:url', article_path(@article.permalink) %>
+  <%= meta_tag 'twitter:url', article_url(@article.permalink) %>
   <% if @article.hero_image.present? %>
     <%= meta_tag 'twitter:image:src', @article.hero_image.url(:resized) %>
   <% end %>


### PR DESCRIPTION
Presumed to have been broken during the blog migration, posting to Facebook via HootSuite no longer pulls in the expected article metadata.

Using the Facebook Open Graph debugger, you can see the issue lies with the `og:url` metatag.

![screen shot 2016-07-18 at 17 36 53](https://cloud.githubusercontent.com/assets/9943/16922633/51e72680-4d0e-11e6-8c07-1e9cd1b57433.png)

Additionally, I compared an article's metatags from now to the past (via archive.org).

Before:

```
<meta property="og:site_name" content="Your Money Advice" />
<meta property="og:title" content="How much do you spend on your household bills?" />
<meta name="og:description" content="We spend nearly £200 on our main household bills each month. Can you cut your bills?" />
<meta property="og:url" content="http://blog.moneyadviceservice.org.uk/how-much-do-you-spend-on-your-household-bills" />
<meta property="og:image" content="https://7069a4cd501a043ace07-df56fe22442d54931c3d0a668e14458b.ssl.cf3.rackcdn.com/files/article/474/hero/resized_man_with_bills.jpg" />
<meta property="og:type" content="article" />

<meta name="twitter:card" content="summary_large_image" />
<meta name="twitter:description" content="We spend nearly £200 on our main household bills each month. Can you cut your bills?" />
<meta name="twitter:url" content="http://blog.moneyadviceservice.org.uk/how-much-do-you-spend-on-your-household-bills" />
<meta name="twitter:image:src" content="https://7069a4cd501a043ace07-df56fe22442d54931c3d0a668e14458b.ssl.cf3.rackcdn.com/files/article/474/hero/resized_man_with_bills.jpg" />
<meta name="twitter:title" content="How much do you spend on your household bills?" />
<meta name="twitter:site" content="@YourMoneyAdvice" />
```

Now:

```
<meta property="og:site_name" content="Your Money Advice" />
<meta property="og:title" content="How much do you spend on your household bills?" />
<meta name="og:description" content="We spend nearly £200 on our main household bills each month. Can you cut your bills?" />
<meta property="og:url" content="/blog/how-much-do-you-spend-on-your-household-bills" />
<meta property="og:image" content="https://masassets.blob.core.windows.net/blog/files/article/474/hero/resized_man_with_bills.jpg" />
<meta property="og:type" content="article" />

<meta name="twitter:card" content="summary_large_image" />
<meta name="twitter:description" content="We spend nearly £200 on our main household bills each month. Can you cut your bills?" />
<meta name="twitter:url" content="/blog/how-much-do-you-spend-on-your-household-bills" />
<meta name="twitter:image:src" content="https://masassets.blob.core.windows.net/blog/files/article/474/hero/resized_man_with_bills.jpg" />
<meta name="twitter:title" content="How much do you spend on your household bills?" />
<meta name="twitter:site" content="@YourMoneyAdvice" />
```

You can see that the url is now populated with a relative path.

This PR simply reinstates the correct full url.