### PR TITLE
[DEV APPROVED] 7467 - Swapping Comments and Related articles

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -62,6 +62,8 @@ $article-tile-text--blue: $white;
 $article-tile-date--blue: $white;
 $article-tile-comments-bg--blue: $bay-of-many;
 
+$article-tile-bg--grey: $concrete;
+
 $article-tile-bg--mas: $atlantis;
 $article-tile-text--mas: $white;
 

--- a/app/assets/stylesheets/components/also_like/_also_like.scss
+++ b/app/assets/stylesheets/components/also_like/_also_like.scss
@@ -1,5 +1,4 @@
 .also-like {
-  background: $concrete;
   clear: both;
 }
 

--- a/app/assets/stylesheets/components/tiles/_article_tile.scss
+++ b/app/assets/stylesheets/components/tiles/_article_tile.scss
@@ -12,6 +12,10 @@ $less-than-mq-l: ($mq-l) - .01;
   background-color: $article-tile-bg--blue;
 }
 
+@mixin article-tile--grey {
+  background-color: $article-tile-bg--grey;
+}
+
 @mixin article-tile--mas {
   background-color: $article-tile-bg--mas;
 }
@@ -161,7 +165,7 @@ $less-than-mq-l: ($mq-l) - .01;
   }
 
   .article-page & {
-    @include article-tile--white;
+    @include article-tile--grey;
   }
 
   .article-page .l-tile:nth-child(3) & {

--- a/app/assets/stylesheets/layouts/_tiles.scss
+++ b/app/assets/stylesheets/layouts/_tiles.scss
@@ -1,13 +1,13 @@
+.l-tiles {
+  @extend %clearfix;
+  margin-bottom: $baseline-unit*4;
+}
+
 .l-tiles__inner {
   @include column(12);
-  margin-top: baseline-unit(4);
 
   .homepage & {
     margin-top: 5px;
-  }
-
-  @include respond-to($mq-m) {
-    margin-top: baseline-unit(9);
   }
 
   .flexbox & {

--- a/app/views/articles/read.html.erb
+++ b/app/views/articles/read.html.erb
@@ -34,6 +34,10 @@
 
       <%= render 'shared/sharing_buttons', url: article_url(@article.permalink) %>
 
+      <div class="l-also-like">
+        <%= render 'shared/also_like' %>
+      </div>
+
       <div class="comments l-constrained">
         <a id="comments"></a>
 
@@ -49,7 +53,3 @@
     </div>
   </div>
 </main>
-
-<div class="l-also-like">
-  <%= render 'shared/also_like' %>
-</div>


### PR DESCRIPTION
## Swapping Comments and Related Articles

As a result of an A/B test the requirement is to swap the comment block and the related articles, please see below for before and after screenshots:

|Before|
|-------|
|![blog--before](https://cloud.githubusercontent.com/assets/13165846/16945864/d7e9423c-4d9e-11e6-8922-43edc74a4121.png)|

|After|
|-----|
|![blog--after](https://cloud.githubusercontent.com/assets/13165846/16945872/e1879618-4d9e-11e6-9b37-6143b1aae090.png)|
