### PR TITLE
[DEV APPROVED] Move asset precompile to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,9 +37,9 @@ cat > public/version <<EOT
 }
 EOT
 
-echo 'Untar precompiled assets'
-echo '-------------------'
-tar -xzvf ../precompiled-assets.tgz
+echo 'Precompiling assets'
+echo '----'
+RAILS_ENV=production RAILS_GROUPS=assets rake assets:precompile
 
 echo 'Running Bundle package'
 echo '----'

--- a/pre-build.sh
+++ b/pre-build.sh
@@ -29,11 +29,3 @@ bundle install
 echo 'Running bowndler'
 echo '-----------------------'
 bowndler update --production --config.interactive=false
-
-echo 'Precompiling assets'
-echo '----'
-RAILS_ENV=production RAILS_GROUPS=assets rake assets:precompile
-
-echo 'Tar precompile assets'
-echo '----'
-tar -czf precompiled-assets.tgz public/assets

--- a/test.sh
+++ b/test.sh
@@ -5,10 +5,6 @@ set -e
 export PATH=./bin:$PATH
 export RAILS_ENV=test
 
-echo 'Untar precompiled assets'
-echo '-------------------'
-tar -xzvf ../precompiled-assets.tgz
-
 echo 'Running Database Schema Load'
 echo '-------------------'
 RAILS_ENV=test bundle exec rake db:schema:load


### PR DESCRIPTION
This was in pre-build.sh, with the results being tarred up for Go to
grab it and send it to the test and build jobs. However, it doesn't
appear to be needed by test so we should be able to get by with only
precompiling in the build job.