### PR TITLE
[DEV APPROVED] Adding search focus component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 source 'http://gems.dev.mas.local'
 ruby '2.2.0'
 
-gem 'dough-ruby', '~> 4.0', git: 'https://github.com/moneyadviceservice/dough.git', require: 'dough'
+gem 'dough-ruby', '~> 5.0', git: 'https://github.com/moneyadviceservice/dough.git', require: 'dough'
 
 gem 'pg'
 gem 'rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,12 @@ GIT
 
 GIT
   remote: https://github.com/moneyadviceservice/dough.git
-  revision: bc5f79550769ec436a1398bd378a8af78185651a
+  revision: ee7a2a62cf6f61afb50397fb26b9554461a610c2
   specs:
-    dough-ruby (4.0.0)
+    dough-ruby (5.19.0)
       activesupport
       rails (>= 3.2)
-      sass-rails
+      sass-rails (~> 4.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -549,7 +549,7 @@ DEPENDENCIES
   csslint_ruby
   database_cleaner
   dotenv-rails
-  dough-ruby (~> 4.0)!
+  dough-ruby (~> 5.0)!
   dynamic_form (~> 1.1.4)
   factory_girl (~> 4.5.0)
   flickraw-cached
@@ -605,4 +605,4 @@ RUBY VERSION
    ruby 2.2.0p0
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -23,7 +23,8 @@
   requirejs_config[:paths].merge!({
     componentLoader: requirejs_path('dough/assets/js/lib/componentLoader'),
     DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),
-    Collapsable: requirejs_path('dough/assets/js/components/Collapsable')
+    Collapsable: requirejs_path('dough/assets/js/components/Collapsable'),
+    SearchFocus: requirejs_path('dough/assets/js/components/SearchFocus')
   })
 %>
 

--- a/app/assets/stylesheets/_enhanced.css.scss
+++ b/app/assets/stylesheets/_enhanced.css.scss
@@ -8,6 +8,8 @@ $responsive: true;
 @import 'dough/assets/stylesheets/common';
 @import 'dough/assets/stylesheets/optional';
 
+@import 'yeast/assets/all';
+
 @import 'lib/functions';
 @import 'lib/mixins';
 

--- a/app/assets/stylesheets/layouts/_footer.scss
+++ b/app/assets/stylesheets/layouts/_footer.scss
@@ -169,6 +169,10 @@
 
 .l-footer-contact__logo {
   display: inline-block;
+
+  &:focus {
+    background-color: transparent;
+  }
 }
 
 .l-footer-contact__logo-image {

--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -152,6 +152,10 @@
   display: block;
   width: 100%;
   height: 100%;
+
+  &:focus {
+    background-color: transparent;
+  }
 }
 
 .l-header__search-button {
@@ -174,6 +178,10 @@
     width: 26px;
     height: 26px;
     background: asset-url('magnify.svg') no-repeat;
+  }
+
+  &:focus {
+    background-color: transparent;
   }
 }
 

--- a/app/views/articles/search.html.erb
+++ b/app/views/articles/search.html.erb
@@ -2,21 +2,21 @@
   <%= rel_next_prev_link_tags @articles %>
 <% end %>
 
-<main id="main" tabindex="-1" class="l-results">
+<main id="main" tabindex="-1" class="l-results" data-dough-component="SearchFocus">
   <div class="l-constrained">
     <div class="results-list">
       <h1 class="results-list__title"><%= t('.search_results_for')%> <% if params[:q] %>'<%= h(params[:q]) %>'<% end %></h1>
       <form class="search-form" action="<%= search_path %>">
         <div class="form__row">
           <label for="q" class="form__label-heading">Search term</label>
-          <input class="search-form__input" type="text" name="q" id="q" value="<%= h(params[:q]) %>" />
+          <input class="search-form__input" type="text" name="q" id="q" value="<%= h(params[:q]) %>" data-dough-search-input />
         </div>
         <div class="form__row">
           <input type="submit" class="button button--primary" />
         </div>
       </form>
       <%- if params[:q] && @articles.empty? %>
-        <p><%= t(".no_articles_found")%></p>
+          <p data-dough-search-noresults><%= t(".no_articles_found")%></p>
       <%- else %>
         <a name="results" id="results"></a>
         <% if @articles.count > 0 %>
@@ -24,7 +24,9 @@
         <% end %>
         <%- @articles.each do |article| %>
           <div class="results-list-item">
-            <h2 class="results-list-item__header"><%= link_to(article.title, article_path(article.permalink)) %></h2>
+            <h2 class="results-list-item__header" data-dough-search-results-item>
+              <%= link_to(article.title, article_path(article.permalink)) %>
+            </h2>
             <div class="results-list-item__author">
               <% if article.author %>
                 <span class="visually-hidden"><%= t("articles.archives.published_by") %></span> <a href="<%= author_path(id: article.author) %>"><%= article.user.nickname %></a> -

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -5,7 +5,8 @@
   "dependencies": {
     "dough": "<%= gem_path('dough-ruby') %>",
     "requirejs": "2.1.*",
-    "jquery": "1.11.*"
+    "jquery": "1.11.*",
+    "yeast": "git://github.com/moneyadviceservice/yeast.git#master"
   },
   "resolutions": {
   }

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -12,7 +12,7 @@ describe Note, type: :model do
       it 'with a nil body, return default error message' do
         note = build(:note, body: nil)
         note.save
-        expect(note.errors[:body]).to eq(["Body can't be blank"])
+        expect(note.errors[:body]).to include("can't be blank")
       end
 
       context 'with an existing note' do

--- a/spec/models/post_type_spec.rb
+++ b/spec/models/post_type_spec.rb
@@ -24,7 +24,7 @@ describe PostType, type: :model do
     expect { PostType.create!(name: 'test') }.not_to raise_error
     test_type = PostType.new(name: 'test')
     expect(test_type).not_to be_valid
-    expect(test_type.errors[:name]).to eq(['Name has already been taken'])
+    expect(test_type.errors[:name]).to include('has already been taken')
   end
 
 end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -9,6 +9,6 @@ describe 'Given an empty redirects table', type: :model do
     redirect = Redirect.new(from_path: 'foo/bar', to_path: '/')
 
     expect(redirect).not_to be_valid
-    expect(redirect.errors[:from_path]).to eq(['From path has already been taken'])
+    expect(redirect.errors[:from_path]).to include('has already been taken')
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -5,7 +5,7 @@ describe Tag, type: :model do
     expect { Tag.create!(name: 'test') }.not_to raise_error
     test_tag = Tag.new(name: 'test')
     expect(test_tag).not_to be_valid
-    expect(test_tag.errors[:name]).to eq(['Name has already been taken'])
+    expect(test_tag.errors[:name]).to include('has already been taken')
   end
 
   it 'display names with spaces can be found by dash joined name' do


### PR DESCRIPTION
## 7558 - Blog: Post search focus should remain on the search box

**The Problem**

When a user performed a search on the blog, the focus would be in the usual place on the results page, so they would have to tab all the way down the the results.

**The Solution**

|1) Force focus to the 1st result if there is a result|
|----------|
|<img width="500" alt="article found" src="https://cloud.githubusercontent.com/assets/13165846/18122029/6ad8fd9e-6f5f-11e6-9d0a-a24657afb770.png">|

|2) If no result is found, the focus is on the search bar|
|----------|
|<img width="500" alt="no articles found" src="https://cloud.githubusercontent.com/assets/13165846/18122053/858c2df0-6f5f-11e6-85d6-33dd2e804a13.png">|

|3)If a user goes directly to the search page, the focus is in the normal place at the top with the accessibility links|
|----------|
|<img width="500" alt="directly to search" src="https://cloud.githubusercontent.com/assets/13165846/18122079/9986192e-6f5f-11e6-83d0-885b561c8043.png">|

## Update 05/09/16

I noticed an issue with the focus styles on the logos (In header and footer) and the search button.  The focus styles are being added from yeast, and were showing solid background colours which caused the logo to dissappear, These have been fixed by adding ``background-color: transparent: `` to the focus style for those elements:

| Logo header | Search button | Footer logo |
|--------------|---------------|------------|
|<img width="259" alt="screen shot 2016-09-05 at 09 29 07" src="https://cloud.githubusercontent.com/assets/13165846/18241987/08b96acc-734c-11e6-90b3-dac030d25b4e.png">|<img width="120" alt="screen shot 2016-09-05 at 09 30 19" src="https://cloud.githubusercontent.com/assets/13165846/18241992/0dfb04aa-734c-11e6-9e77-eacbc1061883.png">|<img width="307" alt="screen shot 2016-09-05 at 09 28 58" src="https://cloud.githubusercontent.com/assets/13165846/18241995/121df13c-734c-11e6-8fd1-846281efd657.png">|

## Testing

To test this change you must pull this branch of dough:
https://github.com/moneyadviceservice/dough/pull/275

And link it to your local publify, as this contains the new dough component used in this PR, for instructions on how to use a local version of dough, see here: https://github.com/moneyadviceservice/dough

## Technical Debt

Publify was still using a very old version of dough, which needed to be updated, and also add Yeast into the mix for the MAS specific SASS mixins and styling.