### PR TITLE
[DEV APPROVED] 7612 - Removing ref to dough git branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 source 'http://gems.dev.mas.local'
 ruby '2.2.0'
 
-gem 'dough-ruby', '~> 5.0', git: 'https://github.com/moneyadviceservice/dough.git', require: 'dough'
+gem 'dough-ruby', '~> 5.0', require: 'dough'
 
 gem 'pg'
 gem 'rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,15 +6,6 @@ GIT
       cocaine
       orm_adapter (~> 0.5.0)
 
-GIT
-  remote: https://github.com/moneyadviceservice/dough.git
-  revision: ee7a2a62cf6f61afb50397fb26b9554461a610c2
-  specs:
-    dough-ruby (5.19.0)
-      activesupport
-      rails (>= 3.2)
-      sass-rails (~> 4.0.0)
-
 GEM
   remote: https://rubygems.org/
   remote: http://gems.dev.mas.local/
@@ -140,6 +131,10 @@ GEM
     dotenv (1.0.2)
     dotenv-rails (1.0.2)
       dotenv (= 1.0.2)
+    dough-ruby (5.19.0.281)
+      activesupport
+      rails (>= 3.2)
+      sass-rails (~> 4.0.0)
     dynamic_form (1.1.4)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -549,7 +544,7 @@ DEPENDENCIES
   csslint_ruby
   database_cleaner
   dotenv-rails
-  dough-ruby (~> 5.0)!
+  dough-ruby (~> 5.0)
   dynamic_form (~> 1.1.4)
   factory_girl (~> 4.5.0)
   flickraw-cached


### PR DESCRIPTION
## 7612 - Removing ref to dough git branch

This PR changes the reference to Dough in the Gemfile from
```
gem 'dough-ruby', '~> 5.0', git: 'https://github.com/moneyadviceservice/dough.git', require: 'dough'
```

to

```
gem 'dough-ruby', '~> 5.0', require: 'dough'
```

So that it does not rely on the github branch, and instead uses the Gem.

It is my understanding that ``require: 'dough'`` is needed as the gem name differs from dependency name (eg in bower.json.erb ``"dough": "<%= gem_path('dough-ruby') %>"``). 