### PR TITLE
[WIP] 7635 - Adding conditional H2 on search page for accessibility

### DIFF
--- a/app/views/articles/search.html.erb
+++ b/app/views/articles/search.html.erb
@@ -15,6 +15,11 @@
           <input type="submit" class="button button--primary" />
         </div>
       </form>
+
+      <%- if params[:q].nil? || @articles.empty? %>
+        <h2 class="visually-hidden">Search Results</h2>
+      <% end %>
+
       <%- if params[:q] && @articles.empty? %>
           <p data-dough-search-noresults><%= t(".no_articles_found")%></p>
       <%- else %>


### PR DESCRIPTION
## 7635 - Adding conditional H2 on search page for accessibility

An illogical heading structure was encountered on the search page, where headings jumped form an h1 to an h3. This can cause confusion for screen reader users. Ensuring that an h2 is present between the h1 and h3 will benefit this user group.

To ensure that the h2 always appears when there are no search results, I have accounted for the following conditions:

| No search query, user lands directly on search page |
|-----------------|
|<img width="878" alt="screen shot 2016-09-26 at 11 12 42" src="https://cloud.githubusercontent.com/assets/13165846/18830920/dcf3ad40-83da-11e6-9c90-5b5aeca9d781.png">|

| Empty search query, user hit search without entering a term |
|------------------|
|![empty search](https://cloud.githubusercontent.com/assets/13165846/18830945/083d83d6-83db-11e6-9d62-28d92fdbe560.png)
<img width="843" alt="screen shot 2016-09-26 at 11 12 49" src="https://cloud.githubusercontent.com/assets/13165846/18830955/15ebe234-83db-11e6-9359-a31388df43fc.png">|

| User performs search, but no results found |
|------------------|
|<img width="881" alt="screen shot 2016-09-26 at 11 12 57" src="https://cloud.githubusercontent.com/assets/13165846/18830988/34f99dd8-83db-11e6-90c4-43b117349109.png">|

| User performs search, articles found |
|-----------------|
| In this scenario, the H2 should not be in the markup, as the search results are H2's:
<img width="938" alt="screen shot 2016-09-26 at 11 13 15" src="https://cloud.githubusercontent.com/assets/13165846/18831022/656eaf9e-83db-11e6-8da0-45137b85f6d6.png">|

