### PR TITLE
[DEV APPROVED] Adding H2 to footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,7 @@
 <footer class="l-footer">
   <div class="l-footer-links">
     <div class="l-constrained">
+      <h2 class="visually-hidden">Footer links</h2>
       <div class="l-footer-links-section">
         <% unless @popular_articles.empty? %>
           <h3 class="l-footer-link__header">What's popular</h3>


### PR DESCRIPTION
## 7635 - Adding H2 to blog footer for accessibility

An illogical heading structure was encountered on the search page, where headings jumped form an h1 to an h3. This can cause confusion for screen reader users. Ensuring that an h2 is present between the h1 and h3 will benefit this user group.

The solution for this is to add a hidden H2 to the footer section ``<h2 class="visually-hidden">Footer links</h2>``. This identifies the links in the footer as a section containing links and ensures that the H3's in the footer follow a H2.