### PR TITLE
[DEV APPROVED] 7637 - A11Y: Change colours on the blog recirculation link

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -64,7 +64,6 @@ $article-tile-comments-bg--blue: $bay-of-many;
 
 $article-tile-bg--grey: $concrete;
 
-$article-tile-bg--mas: $atlantis;
 $article-tile-bg--mas-green: $green-leaf;
 $article-tile-text--mas: $white;
 

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -65,6 +65,7 @@ $article-tile-comments-bg--blue: $bay-of-many;
 $article-tile-bg--grey: $concrete;
 
 $article-tile-bg--mas: $atlantis;
+$article-tile-bg--mas-green: $green-leaf;
 $article-tile-text--mas: $white;
 
 $article-tile-bg--popular: $cream-can;

--- a/app/assets/stylesheets/components/tiles/_article_tile.scss
+++ b/app/assets/stylesheets/components/tiles/_article_tile.scss
@@ -17,7 +17,7 @@ $less-than-mq-l: ($mq-l) - .01;
 }
 
 @mixin article-tile--mas {
-  background-color: $article-tile-bg--mas;
+  background-color: $article-tile-bg--mas-green;
 }
 
 @mixin article-tile--popular {

--- a/app/assets/stylesheets/lib/_colors.scss
+++ b/app/assets/stylesheets/lib/_colors.scss
@@ -28,7 +28,6 @@ $french-pass: #c9edfe !default;
 $chambray: #385b8f !default;
 $shakespeare: #4ea7cf !default;
 $picton-blue: #3f9de3 !default;
-$atlantis: #76b72a !default;
 
 // Reds
 $burnt-sienna: #eb745a !default;


### PR DESCRIPTION
## A11Y: Change colours on the blog recirculation link

**Accessibility Audit page 94** 
The 'You might also like...' links -  the box that links to core site is green on white - at too low a contrast ratio to be accessible.

This PR darkens the green background colour to the MAS green/White scheme to improve contrast.

| Current |
|---------|
|<img width="1193" alt="screen shot 2016-09-27 at 11 23 33" src="https://cloud.githubusercontent.com/assets/13165846/18869586/de2a1332-84a4-11e6-9fab-4556f0f340e2.png">|

| New |
|------|
|<img width="1214" alt="screen shot 2016-09-27 at 11 21 22" src="https://cloud.githubusercontent.com/assets/13165846/18869546/afa4b9c2-84a4-11e6-99ee-0ff8a54b3549.png">|

