### PR TITLE
[DEV APPROVED] TP: 7638, Comment: Updates link styles on blog for better accessibility

### DIFF
--- a/app/assets/stylesheets/_enhanced.css.scss
+++ b/app/assets/stylesheets/_enhanced.css.scss
@@ -1,14 +1,14 @@
 $responsive: true;
 
-// lib/colors must be loaded before the settings file
-@import 'lib/colors';
-@import 'settings';
-
 @import 'dough/assets/stylesheets/lib';
 @import 'dough/assets/stylesheets/common';
 @import 'dough/assets/stylesheets/optional';
 
 @import 'yeast/assets/all';
+
+// lib/colors must be loaded before the settings file
+@import 'lib/colors';
+@import 'settings';
 
 @import 'lib/functions';
 @import 'lib/mixins';

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -3,7 +3,6 @@
 $vertical-grid-spacing: 6 !default;
 
 // link color
-$link-color: $deep-cerulean;
 $link-color--negative: $white;
 
 // typography

--- a/app/assets/stylesheets/base/_links.scss
+++ b/app/assets/stylesheets/base/_links.scss
@@ -1,10 +1,20 @@
- a {
-  color: $link-color;
+a {
   text-decoration: none;
-  
+
+  .l-article__inner p &,
+  .l-footer-links &,
+  .l-footer-contact &:not([href^=tel]) {
+    text-decoration: underline;
+  }
+
   &:hover,
   &:focus {
     text-decoration: underline;
+
+    .l-article__inner p &,
+    .l-footer-links &,
+    .l-footer-contact &:not([href^=tel]) {
+      text-decoration: none;
+    }
   }
 }
-

--- a/app/assets/stylesheets/components/article_body/_inline_callout.scss
+++ b/app/assets/stylesheets/components/article_body/_inline_callout.scss
@@ -43,5 +43,5 @@
 
 .inline-callout__arrow-path {
   fill: none;
-  stroke: $link-color;
+  stroke: $color-link-default;
 }

--- a/app/assets/stylesheets/components/campaigns-link/campaigns-link.scss
+++ b/app/assets/stylesheets/components/campaigns-link/campaigns-link.scss
@@ -2,7 +2,7 @@
   @include font-size(22);
   line-height: 1.2;
   font-weight: 700;
-  color: $eastern-blue;
+  color: $color-link-default;
   display: table;
   width: 100%;
   position: relative;
@@ -18,7 +18,7 @@
   width: 30px;
   height: 34px;
   position: relative;
-  fill: $eastern-blue;
+  fill: $color-link-default;
   display: table-cell;
   vertical-align: top;
 }

--- a/app/assets/stylesheets/components/comments_count/_settings.scss
+++ b/app/assets/stylesheets/components/comments_count/_settings.scss
@@ -1,1 +1,1 @@
-$comment-count-icon-color: $link-color;
+$comment-count-icon-color: $color-link-default;

--- a/app/assets/stylesheets/components/tiles/_article_tile.scss
+++ b/app/assets/stylesheets/components/tiles/_article_tile.scss
@@ -38,12 +38,12 @@ $less-than-mq-l: ($mq-l) - .01;
 }
 
 @mixin article-tile__heading--white {
-  color: $article-tile-text--white;
+  color: $color-link-default;
 
   &:hover,
   &:focus,
   &:visited {
-    color: $article-tile-text--white;
+    color: $color-link-default;
   }
 }
 

--- a/app/assets/stylesheets/layouts/_footer.scss
+++ b/app/assets/stylesheets/layouts/_footer.scss
@@ -62,7 +62,7 @@
   &:active,
   &:focus {
     svg {
-      fill: $link-color;
+      fill: $color-link-default;
     }
   }
 }

--- a/app/views/articles/_comment.html.erb
+++ b/app/views/articles/_comment.html.erb
@@ -7,8 +7,8 @@
   <div class="t-comment-content">
     <%= simple_format(comment.html).nofollowify %>
   </div>
-  <div class="comment-list-item__report-link"><%= report_comment_link(comment) %></div>
+  <p class="comment-list-item__report-link"><%= report_comment_link(comment) %></p>
   <%- unless comment.published %>
-    <div class="spamwarning"><%= t(".this_comment_has_been_flagged_for_moderator_approval") %></div>
+    <p class="spamwarning"><%= t(".this_comment_has_been_flagged_for_moderator_approval") %></p>
   <%- end %>
 </li>


### PR DESCRIPTION
This PR 
- updates the colour of links to the darker blue as used on the core site
- underlines the links (removed for hover state)

**Current (Media centre shows hover state):** 
![image](https://cloud.githubusercontent.com/assets/6080548/18910407/c31743f0-856f-11e6-87fc-f0937581333f.png)

**Updated (Media centre shows hover state):** 
![image](https://cloud.githubusercontent.com/assets/6080548/18910419/cd13d094-856f-11e6-8778-53ce48c81bb1.png)

To do this it removes the publify-specific variable $link-color and uses the variable $color-link-default from Yeast instead in all places that variable has been used (most notably for the hover state of the social sharing icons).