### PR TITLE
[DEV APPROVED] TP: 7640, Comment: Removes title attribute from blog post links

### DIFF
--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,6 +1,6 @@
 <div class="l-tile">
   <div class="article-tile">
-    <h2><%= link_to truncate(article.title, length: 53), article_path(article.permalink), { :class => 'article-tile__heading', :title => article.title } %></h2>
+    <h2><%= link_to truncate(article.title, length: 53), article_path(article.permalink), :class => 'article-tile__heading' %></h2>
 
     <time class="article-tile__date"><%= display_article_date(article) %></time>
     <% if article.published_comments.size > 0 %>

--- a/app/views/shared/_also_like.html.erb
+++ b/app/views/shared/_also_like.html.erb
@@ -7,7 +7,7 @@
         <% if @article.primary_related_content.present? %>
           <div class="l-tile">
             <div class="article-tile">
-              <h5><%= link_to truncate(@article.primary_related_content.title, length: 53), article_path(@article.primary_related_content.permalink), { :class => 'article-tile__heading', :title => @article.primary_related_content.title } %></h5>
+              <h5><%= link_to truncate(@article.primary_related_content.title, length: 53), article_path(@article.primary_related_content.permalink), :class => 'article-tile__heading' %></h5>
               <time class="article-tile__date"><%= display_date_and_time(@article.primary_related_content.published_at) %></time>
             </div>
           </div>
@@ -15,7 +15,7 @@
         <% if @article.secondary_related_content.present? %>
           <div class="l-tile">
             <div class="article-tile">
-              <h5><%= link_to truncate(@article.secondary_related_content.title, length: 53), article_path(@article.secondary_related_content.permalink), { :class => 'article-tile__heading', :title => @article.secondary_related_content.title } %></h5>
+              <h5><%= link_to truncate(@article.secondary_related_content.title, length: 53), article_path(@article.secondary_related_content.permalink), :class => 'article-tile__heading' %></h5>
               <time class="article-tile__date"><%= display_date_and_time(@article.secondary_related_content.published_at) %></time>
             </div>
           </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -9,7 +9,7 @@
           <ol class="unstyled-list l-footer-link__list">
             <% @popular_articles.each do |article| %>
               <li class="l-footer-link__list-item">
-                <%= link_to article.title, article_path(article.permalink), title: article.title %>
+                <%= link_to article.title, article_path(article.permalink) %>
                 <time class="l-footer-link__list-item-time"><%= "#{display_article_date(article)}" %></time>
               </li>
             <% end %>
@@ -23,7 +23,7 @@
         <ol class="unstyled-list l-footer-link__list">
           <% latest_articles.each do |article| %>
             <li class="l-footer-link__list-item">
-              <%= link_to article.title, article_path(article.permalink), title: article.title %>
+              <%= link_to article.title, article_path(article.permalink) %>
               <time class="l-footer-link__list-item-time"><%= "#{display_article_date(article)}" %></time>
             </li>
           <% end %>


### PR DESCRIPTION
This PR removes the title attribute from links to blog posts in four areas: 
* Home page:
 * the links in tiles
 * under "What's popular"
 * under "Latest posts"
* post page: 
 * under "You might also like" 