### PR TITLE
[DEV APPROVED] 7644 - Updating blog commenting policy links

### DIFF
--- a/app/views/articles/_comment_form.html.erb
+++ b/app/views/articles/_comment_form.html.erb
@@ -29,7 +29,7 @@
     <% end %>
 
     <div class="comment-form__group comment-form__group--policy">
-      <p><%= t(".by_clicking_on") %><a href="/pages/commenting-policy"><%= t(".commenting_policy") %></a></p>
+      <p><%= t(".by_clicking_on") %><a href="/blog/pages/commenting-policy"><%= t(".commenting_policy") %></a></p>
     </div>
 
     <div class="comment-form__group comment-form__group--submit">

--- a/app/views/articles/read.html.erb
+++ b/app/views/articles/read.html.erb
@@ -42,7 +42,7 @@
         <a id="comments"></a>
 
         <h2 class="comments__headline"><%= t(".what_do_you_think")%></h2>
-        <p class="comments__text"><%= t(".really_want_to_share_your_views") %> <a href="/pages/commenting-policy"><%= t(".full_commenting_guidelines") %></a></p>
+        <p class="comments__text"><%= t(".really_want_to_share_your_views") %> <a href="/blog/pages/commenting-policy"><%= t(".full_commenting_guidelines") %></a></p>
 
         <% if @article.allow_comments? -%>
           <%= render "articles/comment_form" %>


### PR DESCRIPTION
## 7644 - Updating blog commenting policy links

The Blog comments module links to the blog comment policy twice (once above and once below the comment)
 
Both of these currently link to: https://www.moneyadviceservice.org.uk/pages/commenting-policy  - which does not exist
 
They should link, instead to: https://www.moneyadviceservice.org.uk/blog/pages/commenting-policy
 
Presumably this bug has snuck in since the blog migration

This PR fixes this problem