### PR TITLE
[DEV APPROVED] 7673 - Adding focusable false to SVGs

### DIFF
--- a/app/views/archives/kaminari/_paginator.html.erb
+++ b/app/views/archives/kaminari/_paginator.html.erb
@@ -1,6 +1,6 @@
 <%= paginator.render do -%>
   <div class="l-tile l-tile--archive">
-    <a href="/archives" class="l-index-archive__link">All Articles <svg class="l-index-archive__link-arrow">
+    <a href="/archives" class="l-index-archive__link">All Articles <svg class="l-index-archive__link-arrow" focusable="false">
         <use xlink:href="#svg-arrow-right"></use>
       </svg>
     </a>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -17,7 +17,7 @@
           <div class="l-tile l-tile--archive">
             <a href="<%= archives_path %>" class="l-index-archive__link">
               All Articles
-              <svg class="l-index-archive__link-arrow">
+              <svg class="l-index-archive__link-arrow" focusable="false">
                 <use xlink:href="#svg-arrow-right"></use>
               </svg>
             </a>

--- a/app/views/shared/_campaign_link_article.html.erb
+++ b/app/views/shared/_campaign_link_article.html.erb
@@ -4,7 +4,7 @@
       <%= link.title %>
     </span>
     <span class="campaigns-link__arrow">
-      <svg class="campaigns-link__arrow__icon">
+      <svg class="campaigns-link__arrow__icon" focusable="false">
         <use xlink:href="#svg-arrow-right"></use>
       </svg>
     </span>

--- a/app/views/shared/_campaign_link_masays.html.erb
+++ b/app/views/shared/_campaign_link_masays.html.erb
@@ -4,7 +4,7 @@
       <%= link.title %>
     </span>
     <span class="campaigns-link__arrow">
-      <svg class="campaigns-link__arrow__icon">
+      <svg class="campaigns-link__arrow__icon" focusable="false">
         <use xlink:href="#svg-arrow-right"></use>
       </svg>
     </span>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -62,7 +62,7 @@
         <ol class="unstyled-list l-footer-social__list">
           <li class="l-footer-social__list-item twitter">
             <a href="http://twitter.com/YourMoneyAdvice" title="Your Money Advice on Twitter" class="l-footer-social__link">
-              <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" viewBox="0 0 29 24" enable-background="new 0 0 29 24" xml:space="preserve"  aria-labelledby="social-sharing-twitter">
+              <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" viewBox="0 0 29 24" enable-background="new 0 0 29 24" xml:space="preserve"  aria-labelledby="social-sharing-twitter" focusable="false">
                 <title id="social-sharing-twitter">Your Money Advice on Twitter</title>
                 <path d="M29 2.8c-1.1 0.5-2.2 0.8-3.4 1c1.2-0.7 2.2-1.9 2.6-3.4c-1.1 0.7-2.4 1.2-3.8 1.5C23.3 0.7 21.8 0 20.1 0 c-3.3 0-5.9 2.7-5.9 6.1c0 0.5 0.1 0.9 0.2 1.4C9.3 7.2 5 4.8 2 1.1C1.5 2 1.2 3 1.2 4.2c0 2.1 1 4 2.6 5c-1 0-1.9-0.3-2.7-0.8 c0 0 0 0.1 0 0.1c0 2.9 2.1 5.4 4.8 5.9c-0.5 0.1-1 0.2-1.6 0.2c-0.4 0-0.8 0-1.1-0.1c0.8 2.4 3 4.2 5.6 4.2c-2 1.6-4.6 2.6-7.4 2.6 c-0.5 0-1 0-1.4-0.1C2.6 23 5.8 24 9.1 24C20.1 24 26 14.8 26 6.8c0-0.3 0-0.5 0-0.8C27.2 5.1 28.2 4.1 29 2.8z"/>
               </svg>
@@ -70,7 +70,7 @@
           </li>
           <li class="l-footer-social__list-item facebook">
             <a href="https://www.facebook.com/MoneyAdviceService" title="Money Advice Service Facebook page" class="l-footer-social__link">
-              <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" viewBox="0 0 12 25" enable-background="new 0 0 12 25" xml:space="preserve" aria-labelledby="social-sharing-facebook">
+              <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" viewBox="0 0 12 25" enable-background="new 0 0 12 25" xml:space="preserve" aria-labelledby="social-sharing-facebook" focusable="false">
                 <title id="social-sharing-facebook">Money Advice Service Facebook page</title>
                 <path d="M12 8.1H7.9V5.5c0-1 0.6-1.2 1.1-1.2c0.5 0 2.9 0 2.9 0V0L8 0C3.6 0 2.5 3.2 2.5 5.2v2.9H0v4.4h2.5c0 5.7 0 12.5 0 12.5h5.4 c0 0 0-6.9 0-12.5h3.6L12 8.1z"/>
               </svg>
@@ -78,7 +78,7 @@
           </li>
           <li class="l-footer-social__list-item youtube">
             <a href="https://www.youtube.com/user/MoneyAdviceService" title="Money Advice Service on YouTube" class="l-footer-social__link">
-              <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="YouTube_Logo" x="0px" y="0px" viewBox="0 0 503 213" enable-background="new 0 0 503 213" xml:space="preserve" aria-labelledby="social-sharing-youtube">
+              <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="YouTube_Logo" x="0px" y="0px" viewBox="0 0 503 213" enable-background="new 0 0 503 213" xml:space="preserve" aria-labelledby="social-sharing-youtube" focusable="false">
                 <title id="social-sharing-youtube">Money Advice Service on YouTube</title>
                 <g id="You">
                   <path id="u_2_" stroke="#FFFFFF" stroke-miterlimit="10" d="M188 171h-19v-11c-7.2 8.3-13.3 12.4-20 12.4c-5.8 0-9.9-2.8-11.9-7.7 c-1.2-3-2.1-7.8-2.1-14.7V70h19v75c0 4.2 0 6 0 7c0.4 2.8 1.6 3.8 4.1 3.8c3.6 0 6.9-3.2 10.9-8.8V70h19V171z"/>
@@ -100,14 +100,14 @@
     </div>
   </div>
   <div class="l-footer-clouds">
-    <svg class="l-footer-clouds__image" preserveAspectRatio="xMaxYMax slice" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1864 242" enable-background="new 0 0 1864 242"><path fill="#F3F3F3" d="M0 0h1864s-205 236-617 239c0 0-336.7 35-570.3-131.7 0 0-202.7 57.7-355.7 27.7 0 0-202.7-27-321-135z"/></svg>
+    <svg class="l-footer-clouds__image" preserveAspectRatio="xMaxYMax slice" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1864 242" enable-background="new 0 0 1864 242" focusable="false"><path fill="#F3F3F3" d="M0 0h1864s-205 236-617 239c0 0-336.7 35-570.3-131.7 0 0-202.7 57.7-355.7 27.7 0 0-202.7-27-321-135z"/></svg>
   </div>
 
   <div class="l-footer-contact">
     <div class="l-constrained">
       <div class="l-footer-contact__right">
         <a class="l-footer-contact__logo" href="http://www.moneyadviceservice.org.uk">
-          <svg class="l-footer-contact__logo-image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 283.6 45" aria-labelledby="FooterLogoTitle FooterLogoDesc">
+          <svg class="l-footer-contact__logo-image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 283.6 45" aria-labelledby="FooterLogoTitle FooterLogoDesc" focusable="false">
             <title id="FooterLogoTitle">Money Advice Service</title>
             <desc id="FooterLogoDesc">Money Advice Service main site</desc>
             <g fill="#2E3030">

--- a/app/views/tags/kaminari/_next_page.html.erb
+++ b/app/views/tags/kaminari/_next_page.html.erb
@@ -1,6 +1,6 @@
 <% unless current_page.last? %>
   <div class="l-tile l-tile--archive">
-    <a href="<%= url %>" class="l-index-archive__link">Older articles <svg class="l-index-archive__link-arrow">
+    <a href="<%= url %>" class="l-index-archive__link">Older articles <svg class="l-index-archive__link-arrow" focusable="false">
         <use xlink:href="#svg-arrow-right"></use>
       </svg>
     </a>


### PR DESCRIPTION
## 7673 - Adding focusable false to SVGs

This PR removes SVG's from the tab order, ``tabindex="-1"`` was mentioned in the ticket for this task but had no effect in IE11, ``focusable="false"`` worked in all cases.

**Related PR's**

Dough
https://github.com/moneyadviceservice/dough/pull/276

Frontend
https://github.com/moneyadviceservice/frontend/pull/1566