### PR TITLE
[DEV APPROVED] 7679 - Adding TITLE prompt to cost calculator iframe embed

### DIFF
--- a/app/views/admin/contents/_form.html.erb
+++ b/app/views/admin/contents/_form.html.erb
@@ -294,13 +294,15 @@
         <h2>Insert cost calculator</h2>
       </div>
       <div class="modal-body">
-        <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button. <b>Note:</b> Replace [CALC_ID] with the ID of the cost calculator you wish to embed.</p>
+        <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button.</p>
+        <p><b>Note:</b> Give this iframe a title by replacing [TITLE] and replace [CALC_ID] with the ID of the cost calculator you wish to embed.</p>
         <textarea disabled="true" class="modal-body__code">
           <iframe id="calculator_embed"
             frameborder="0"
             width="100%"
             height="1000px"
             class="calculator-preview__iframe"
+            title="[TITLE]"
             src="https://www.moneyadviceservice.org.uk/en/cost-calculator-builder/embed/calculators/[CALC_ID]">
           </iframe>
           <script src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/cost_calculator_builder/embed-06ce0df8c79534fead5871af5a3875bd.js"></script>


### PR DESCRIPTION
## 7679 - A11Y - Allow Iframe titles to appear on blog

Publify allows for the insertion of iframes, which the blog team uses to embed Infogram infographics, quizzes and surveys into their content. As the Accessibility report (p33-34) highlights, iframes need title attributes in order to pass AA Accessibility.

However the blog does not have anything which would remove markup, what goes into the source will be rendered onto the page as it is.

The solution is to ensure that the content team know to include a title tag to iframes pasted in from other sources (Which Ed will do).  For cost calculators they embed through publify, the prompt has been changed to request that an iframe title is added when they use the code snippet:

<img width="632" alt="screen shot 2016-10-28 at 10 14 13" src="https://cloud.githubusercontent.com/assets/13165846/19803015/61e4f5c2-9cfe-11e6-868d-aba881681fcf.png">
