### PR TITLE
[DEV APPROVED] 7731 - Blog: Copying snippet code struggle

### DIFF
--- a/app/views/admin/contents/_form.html.erb
+++ b/app/views/admin/contents/_form.html.erb
@@ -238,7 +238,7 @@
       </div>
       <div class="modal-body">
         <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button.</p>
-        <textarea disabled="true" class="modal-body__code">
+        <textarea readonly="true" class="modal-body__code">
 <hr class="snippet" data-snippet-name="inlinecallout" data-snippet-text="[ENTER LINK TEXT HERE]" data-snippet-url="[ENTER LINK URL HERE]" />
         </textarea>
       </div>
@@ -257,7 +257,7 @@
       </div>
       <div class='modal-body'>
         <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button.</p>
-        <textarea disabled="true" class="modal-body__code">
+        <textarea readonly="true" class="modal-body__code">
 <hr class="snippet" data-snippet-name="masays" data-snippet-text="[ENTER LINK TEXT HERE]" data-snippet-url="[ENTER LINK URL HERE]" />
         </textarea>
       </div>
@@ -276,7 +276,7 @@
       </div>
       <div class="modal-body">
         <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button. <b>Note:</b> Add a \n to the answer to start a new paragraph.</p>
-        <textarea disabled="true" class="modal-body__code">
+        <textarea readonly="true" class="modal-body__code">
 <hr class="snippet" data-snippet-name="answerreveal" data-snippet-text-question="[ENTER QUESTION TEXT HERE]" data-snippet-text-answer="[ENTER ANSWER TEXT HERE]" data-snippet-text-callout="[ENTER CALLOUT TEXT HERE]" data-snippet-url-callout="[ENTER CALLOUT URL HERE]" />
         </textarea>
       </div>
@@ -296,7 +296,7 @@
       <div class="modal-body">
         <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button.</p>
         <p><b>Note:</b> Give this iframe a title by replacing [TITLE] and replace [CALC_ID] with the ID of the cost calculator you wish to embed.</p>
-        <textarea disabled="true" class="modal-body__code">
+        <textarea readonly="true" class="modal-body__code">
           <iframe id="calculator_embed"
             frameborder="0"
             width="100%"
@@ -323,7 +323,7 @@
       </div>
       <div class="modal-body">
         <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button. <b>Note:</b> Replace [BRIGHT_ID] with the ID of video you wish to embed.</p>
-        <textarea disabled="true" class="modal-body__code">
+        <textarea readonly="true" class="modal-body__code">
           <div class="mas-video-container">
             <div class="mas-video">
               <iframe src='//players.brightcove.net/3608769895001/b15c0e6a-51da-4bb1-b717-bccae778670d_default/index.html?videoId=[BRIGHT_ID]'
@@ -353,7 +353,7 @@
       </div>
       <div class="modal-body">
         <p>Copy the snippet below and paste it to the desired place by clicking on the 'Source' button. <b>Note:</b> Replace [YOUTUBE_EMBED_CODE] with the embed code of the YouTube Video.</p>
-        <textarea disabled="true" class="modal-body__code">
+        <textarea readonly="true" class="modal-body__code">
           <div class="mas-video-container">
             <div class="mas-video">
               [YOUTUBE_EMBED_CODE]


### PR DESCRIPTION
There has been a change somewhere down the line either to our code or a browser update that meant that a content editor on the blog was unable to highlight the code snippets for cost calculator etc...

This fixes the problem by adding a readonly=true attribute to the textareas which contain the snippets:

<img width="609" alt="screen shot 2016-11-04 at 11 21 01" src="https://cloud.githubusercontent.com/assets/13165846/20003882/d3ea5680-a280-11e6-8d28-0a2b866a05a9.png">

The text areas can now be selected and no edited by the content editors.

Tested across the following browsers:

Firefox
Chrome
Safari
IE8
IE9
IE10
IE11
MSEDGE