### PR TITLE
[DEV APPROVED]Add support for Google AMP.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem 'jbuilder'
 gem 'webpurify', require: 'web_purify'
 gem 'rack-trailing_slashes'
 gem 'newrelic_rpm'
+gem 'nokogiri'
+gem 'fastimage'
 
 gem 'jquery-rails', '~> 3.1.0'
 gem 'jquery-ui-rails', '~> 5.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
+    fastimage (2.0.1)
+      addressable (~> 2)
     ffi (1.9.6)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
@@ -547,6 +549,7 @@ DEPENDENCIES
   dough-ruby (~> 5.0)
   dynamic_form (~> 1.1.4)
   factory_girl (~> 4.5.0)
+  fastimage
   flickraw-cached
   fog
   foreman
@@ -568,6 +571,7 @@ DEPENDENCIES
   mailjet
   mini_magick (~> 3.8.1)
   newrelic_rpm
+  nokogiri
   non-stupid-digest-assets
   oauth2 (= 1.0.0)
   pg
@@ -600,4 +604,4 @@ RUBY VERSION
    ruby 2.2.0p0
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/app/assets/stylesheets/amp_styles.css.scss
+++ b/app/assets/stylesheets/amp_styles.css.scss
@@ -1,0 +1,10 @@
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}

--- a/app/assets/stylesheets/amp_styles.css.scss
+++ b/app/assets/stylesheets/amp_styles.css.scss
@@ -1,3 +1,68 @@
+$responsive: true;
+@import 'lib/_colors';
+@import 'yeast/assets/lib/_variables';
+
+@font-face {
+  font-family: Museo Sans;
+  src: asset-data-url('dough/assets/fonts/MuseoSans_300.woff');
+  font-weight: 300;
+}
+
+@font-face {
+  font-family: Museo Sans;
+  src: asset-data-url('dough/assets/fonts/MuseoSans_700.woff');
+  font-weight: 700;
+}
+
+// AMP specific classes
+.amp-article {
+  color: $color-grey-primary;
+  font-weight: 300;
+  line-height: 1.5rem;
+  font-size: 1.125rem;
+  -webkit-font-smoothing: antialiased;
+  padding: 0 0.6rem 1rem 0.6rem;
+  background-color: white;
+  overflow: auto;
+}
+
+.amp-article__header {
+  background-color: $color-blue-cerulean;
+  min-height: 3.375rem;
+  padding: 0.8rem 0.4rem 0.5rem 0.4rem;
+}
+
+.amp-article__header-logo {
+  border-bottom: 1px solid #1f5d8e;
+}
+
+.amp-article__mas-logo {
+  width: 12rem;
+  background-size: cover;
+  margin: 0 0 1.5rem 0;
+}
+
+.amp-article__header-logo {
+  font-size: 1.125rem;
+  color: $white;
+  text-decoration: none;
+  font-weight: 700;
+  margin: 1.5rem 0 1rem 0;
+  display: inline-block;
+}
+
+.amp-body {
+  max-width: 36rem;
+  margin: 0 auto;
+  font-family: Museo Sans;
+}
+
+.amp-article p:first-of-type {
+  font-size: 1.375rem;
+  color: $astronaut-blue;
+  margin-top: 0;
+}
+
 .visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);

--- a/app/assets/stylesheets/amp_styles.css.scss
+++ b/app/assets/stylesheets/amp_styles.css.scss
@@ -63,6 +63,101 @@ $responsive: true;
   margin-top: 0;
 }
 
+.amp-article p:first-of-type {
+  font-size: 1.375rem;
+  color: $astronaut-blue;
+  margin-top: 0;
+}
+
+body {
+  background-color: $color-grey-pale;
+}
+
+h1 {
+  font-size: 2.25rem;
+  line-height: 2.25rem;
+  margin-top: 0;
+  padding-top: 2rem;
+  margin-bottom: 1rem;
+  color: $outer-space;
+}
+
+h2 {
+  font-size: 1.4rem;
+  line-height: 2rem;
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+  color: $color-green-secondary;
+}
+
+h3 {
+  font-size: 1.375rem;
+  line-height: 1.875rem;
+  margin-top: 1.375rem;
+  margin-bottom: 0.6875rem;
+  color: $color-green-secondary;
+}
+
+a {
+  color: $color-blue-medium;
+}
+
+strong {
+  font-weight: 700;
+}
+
+.inline-callout, .next-steps {
+  padding: 1rem;
+  overflow: hidden;
+}
+
+.inline-callout {
+  background: repeating-linear-gradient(135deg,white,white 19px,#777 20px, white 21px);
+}
+
+.next-steps {
+  background-color: $green-leaf;
+  border-radius: 20px;
+  position: relative;
+}
+
+.inline-callout__text, .next-steps__text {
+  position: relative;
+  float: right;
+  text-align: right;
+  padding: 0.7rem 2.9rem 0.7rem 0.7rem;
+}
+
+.inline-callout__text {
+  background-color: white;
+  color: $green-leaf;
+}
+
+.next-steps__text {
+  color: white;
+  font-weight: 700;
+  font-size: 1.3rem;
+  line-height: 2rem;
+  text-decoration: none;
+}
+
+.inline-callout__arrow, .next-steps__arrow {
+  position: absolute;
+  top: 23%;
+  right: 1rem;
+  width: 1rem;
+  height: 2rem;
+}
+
+.inline-callout__arrow {
+  fill: none;
+  stroke: $green-leaf;
+}
+
+.next-steps__arrow {
+  fill: white;
+}
+
 .visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);

--- a/app/controllers/amp_articles_controller.rb
+++ b/app/controllers/amp_articles_controller.rb
@@ -1,0 +1,9 @@
+class AmpArticlesController < ActionController::Base
+  def show
+    if (@article = Article.find_by_permalink(params[:from])).present?
+      render 'articles/amp/show'
+    else
+      render 'errors/404', status: 404
+    end
+  end
+end

--- a/app/controllers/amp_articles_controller.rb
+++ b/app/controllers/amp_articles_controller.rb
@@ -1,7 +1,11 @@
 class AmpArticlesController < ActionController::Base
   def show
     if (@article = Article.find_by_permalink(params[:from])).present?
-      render 'articles/amp/show'
+      if @article.supports_amp? || params[:no_redirect]
+        render 'articles/amp/show'
+      else
+        redirect_to article_url(@article.permalink)
+      end
     else
       render 'errors/404', status: 404
     end

--- a/app/controllers/amp_articles_controller.rb
+++ b/app/controllers/amp_articles_controller.rb
@@ -10,4 +10,9 @@ class AmpArticlesController < ActionController::Base
       render 'errors/404', status: 404
     end
   end
+
+  def article_body(article)
+    AMPProcessor.new(article).call
+  end
+  helper_method :article_body
 end

--- a/app/models/amp_processor.rb
+++ b/app/models/amp_processor.rb
@@ -1,0 +1,40 @@
+require 'nokogiri'
+
+class AMPProcessor
+  attr_reader :article
+
+  def initialize(article)
+    @article = article
+  end
+
+  def call
+    process_img_tags!
+    process_iframe_tags!
+    doc.to_s
+  end
+
+  private
+
+  def doc
+    @doc ||= Nokogiri::HTML.fragment(article.html(:body))
+  end
+
+  private
+
+  def process_iframe_tags!
+    doc.search('iframe').each do |iframe|
+      iframe.replace "<amp-iframe width='#{iframe['width']}' height='#{iframe['height']}' layout='responsive' sandbox='allow-scripts allow-same-origin' allowfullscreen frameborder='0' src='https:#{iframe['src']}'></amp-iframe>"
+    end
+  end
+
+  def process_img_tags!
+    doc.search('img').each do |image|
+      sizes = FastImage.size(image['src'])
+      if sizes.nil?
+        image.remove
+      else
+        image.replace "<amp-img alt='#{image['alt']}' src='#{image['src']}' layout='responsive' width='#{sizes[0]}' height='#{sizes[1]}'></amp-img>"
+      end
+    end
+  end
+end

--- a/app/views/admin/contents/_form.html.erb
+++ b/app/views/admin/contents/_form.html.erb
@@ -184,6 +184,10 @@
             <%= check_box 'article', 'allow_comments' %>
             <label for="article_allow_comments"><%= t('.allow_comments') %></label>
           </div>
+          <div class="form-row">
+            <%= check_box 'article', 'supports_amp' %>
+            <label for="article_supports_amp"><%= t('.supports_amp') %></label>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/articles/amp/show.html.erb
+++ b/app/views/articles/amp/show.html.erb
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en" ⚡>
+<head>
+</head>
+<body>
+</body>
+</html>

--- a/app/views/articles/amp/show.html.erb
+++ b/app/views/articles/amp/show.html.erb
@@ -34,6 +34,16 @@
       </div>
       <a href="<%= root_path %>" class="amp-article__header-logo">Your Money Advice <span class="visually-hidden">home page</span></a>
     </header>
+
+    <% if @article.hero_image.present? %>
+      <amp-img src="<%= @article.hero_image.url(:resized) %>" alt="<%=@article.hero_image_alt_text %>" height="200" width="576" layout="responsive"></amp-img>
+    <% end %>
+
+    <div class="amp-article">
+      <h1><%= @article.title %></h1>
+        <%= @article.html(:body) %>
+        <%= @article.html(:extended) %>
+    </div>
   </div>
 
   <!-- This is an svg arrow that is used in next steps of an article -->

--- a/app/views/articles/amp/show.html.erb
+++ b/app/views/articles/amp/show.html.erb
@@ -1,6 +1,18 @@
 <!DOCTYPE html>
 <html lang="en" ⚡>
 <head>
+  <meta charset="utf-8">
+
+  <!-- AMP JS libs -->
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+
+  <!-- AMP Boilerplate CSS And Fonts -->
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <!-- Link to main article page -->
+  <link rel="canonical" href="<%= article_url(@article.permalink) %>" />
+
+  <title><%= @article.title %> - Money Advice Service</title>
 </head>
 <body>
 </body>

--- a/app/views/articles/amp/show.html.erb
+++ b/app/views/articles/amp/show.html.erb
@@ -19,5 +19,9 @@
 <body>
 <!-- Google Tag Manager -->
 <amp-analytics config="https://www.googletagmanager.com/amp.json?id=GTM-P66RC5D&gtm.url=SOURCE_URL" data-credentials="include"></amp-analytics>
+  <!-- This is an svg arrow that is used in next steps of an article -->
+  <div class="visually-hidden">
+    <%= render 'shared/svg_sprite', no_styles: true %>
+  </div>
 </body>
 </html>

--- a/app/views/articles/amp/show.html.erb
+++ b/app/views/articles/amp/show.html.erb
@@ -11,6 +11,12 @@
 
   <!-- AMP Boilerplate CSS And Fonts -->
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+
+  <!-- Custom Css -->
+  <style amp-custom>
+    <%= Rails.application.assets["amp_styles.css"] %>
+  </style>
+
   <!-- Link to main article page -->
   <link rel="canonical" href="<%= article_url(@article.permalink) %>" />
 
@@ -19,6 +25,17 @@
 <body>
 <!-- Google Tag Manager -->
 <amp-analytics config="https://www.googletagmanager.com/amp.json?id=GTM-P66RC5D&gtm.url=SOURCE_URL" data-credentials="include"></amp-analytics>
+  <div class="amp-body">
+    <header class="amp-article__header">
+      <div class="amp-article__header-logo">
+        <a href="http://moneyadviceservice.org.uk">
+          <amp-img class="amp-article__mas-logo" src="<%= image_path "logo.svg" %>" alt="Money Advice Service" height="30" width="200"></amp-img>
+        </a>
+      </div>
+      <a href="<%= root_path %>" class="amp-article__header-logo">Your Money Advice <span class="visually-hidden">home page</span></a>
+    </header>
+  </div>
+
   <!-- This is an svg arrow that is used in next steps of an article -->
   <div class="visually-hidden">
     <%= render 'shared/svg_sprite', no_styles: true %>

--- a/app/views/articles/amp/show.html.erb
+++ b/app/views/articles/amp/show.html.erb
@@ -6,6 +6,7 @@
   <!-- AMP JS libs -->
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
 
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 
@@ -41,8 +42,7 @@
 
     <div class="amp-article">
       <h1><%= @article.title %></h1>
-        <%= @article.html(:body) %>
-        <%= @article.html(:extended) %>
+      <%= article_body(@article) %>
     </div>
   </div>
 

--- a/app/views/articles/amp/show.html.erb
+++ b/app/views/articles/amp/show.html.erb
@@ -5,6 +5,8 @@
 
   <!-- AMP JS libs -->
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 
   <!-- AMP Boilerplate CSS And Fonts -->
@@ -15,5 +17,7 @@
   <title><%= @article.title %> - Money Advice Service</title>
 </head>
 <body>
+<!-- Google Tag Manager -->
+<amp-analytics config="https://www.googletagmanager.com/amp.json?id=GTM-P66RC5D&gtm.url=SOURCE_URL" data-credentials="include"></amp-analytics>
 </body>
 </html>

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -16,6 +16,9 @@
   <% if @article.hero_image.present? %>
     <%= meta_tag 'twitter:image:src', @article.hero_image.url(:resized) %>
   <% end %>
+  <% if @article.supports_amp %>
+    <%= tag :link, :href => amp_article_url(@article.permalink), :rel => :amphtml %>
+  <% end %>
 <% end %>
 <%= meta_tag 'twitter:title', @article ? @article.title : @page_title %>
 <%= meta_tag 'twitter:site', '@YourMoneyAdvice' %>

--- a/app/views/shared/_svg_sprite.html.erb
+++ b/app/views/shared/_svg_sprite.html.erb
@@ -5,7 +5,7 @@
   #   <use xlink:href="#svg-arrow-right"></use>
   # </svg>
 %>
-<svg style="display: none;">
+<svg <%= 'style="display: none;"' unless local_assigns[:no_styles] %>>
   <symbol id="svg-arrow-right" viewBox="0 0 22 34">
     <polygon points="0,5 5,0 22,17 5.1,34 0,29 12,17" />
   </symbol>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -757,6 +757,7 @@ en:
         change: "Change"
         publish_at_note: "If left blank, populates automatically with the current time when publishing"
         allow_comments: "Allow comments"
+        supports_amp: "Supports AMP"
         ok: "OK"
         visibility: "Visibility"
         password: "Password"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,5 +110,6 @@ Rails.application.routes.draw do
 
   root to: 'articles#index', format: false
 
+  get '*from/amp', to: 'amp_articles#show', as: :amp_article
   get '*from', to: 'articles#show', as: :article
 end

--- a/db/migrate/20161129152334_add_supports_amp_to_content.rb
+++ b/db/migrate/20161129152334_add_supports_amp_to_content.rb
@@ -1,0 +1,21 @@
+class AddSupportsAmpToContent < ActiveRecord::Migration
+  NON_AMP_ARTICLES = [
+    461, 607, 834, 213, 231, 244, 806, 251, 259, 271, 286, 297, 313,
+    316, 323, 325, 326, 330, 331, 332, 336, 338, 339, 341, 344, 345,
+    346, 349, 351, 355, 356, 360, 361, 368, 371, 384, 406, 411, 415,
+    416, 434, 451, 452, 464, 474, 475, 492, 498, 499, 509, 513, 535,
+    544, 550, 552, 554, 559, 569, 575, 581, 583, 590, 595, 601, 603,
+    811, 616, 619, 623, 627, 638, 646, 647, 657, 820, 659, 664, 673,
+    676, 679, 685, 701, 702, 703, 705, 706, 722, 724, 742, 744, 751,
+    788, 792, 795, 799, 821, 835, 843, 845, 856, 866, 868, 900, 910
+  ]
+
+  def up
+    add_column :contents, :supports_amp, :boolean, default: true
+    Article.where(id: NON_AMP_ARTICLES).update_all("supports_amp = false")
+  end
+
+  def down
+    remove_column :contents, :supports_amp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160722103717) do
+ActiveRecord::Schema.define(version: 20161129152334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 20160722103717) do
     t.string   "description_meta_tag"
     t.integer  "primary_related_content_id"
     t.integer  "secondary_related_content_id"
+    t.boolean  "supports_amp",                             default: true
   end
 
   add_index "contents", ["published"], name: "index_contents_on_published", using: :btree

--- a/spec/controllers/amp_articles_controller_spec.rb
+++ b/spec/controllers/amp_articles_controller_spec.rb
@@ -1,19 +1,44 @@
 # coding: utf-8
 describe AmpArticlesController, 'base', type: :controller do
   let!(:blog) { create(:blog) }
+  let(:params) { {} }
 
   describe '#show' do
-    let!(:article) { create(:article, permalink: 'second-blog-article', published_at: '2004-04-01 02:00:00', updated_at: '2004-04-01 02:00:00', created_at: '2004-04-01 02:00:00') }
+    let!(:article) { create(:article, permalink: 'second-blog-article', published_at: '2004-04-01 02:00:00', updated_at: '2004-04-01 02:00:00', created_at: '2004-04-01 02:00:00', supports_amp: supports_amp) }
     before(:each) do
-      get :show, from: "#{article.permalink}"
+      get :show, { from: "#{article.permalink}" }.merge(params)
     end
 
-    it 'should render template read to article' do
-      expect(response).to render_template('articles/amp/show')
+    context 'it supports amp' do
+      let(:supports_amp) { true }
+
+      it 'should render template read to article' do
+        expect(response).to render_template('articles/amp/show')
+      end
+
+      it 'should assign article1 to @article' do
+        expect(assigns(:article)).to eq(article)
+      end
     end
 
-    it 'should assign article1 to @article' do
-      expect(assigns(:article)).to eq(article)
+    context 'it does not support amp' do
+      let(:supports_amp) { false }
+
+      it 'returns a 302' do
+        expect(response.status).to eql(302)
+      end
+
+      context 'has no_redirect param' do
+        let(:params) { { no_redirect: true } }
+
+        it 'should render template read to article' do
+          expect(response).to render_template('articles/amp/show')
+        end
+
+        it 'should assign article1 to @article' do
+          expect(assigns(:article)).to eq(article)
+        end
+      end
     end
   end
 end

--- a/spec/controllers/amp_articles_controller_spec.rb
+++ b/spec/controllers/amp_articles_controller_spec.rb
@@ -1,0 +1,19 @@
+# coding: utf-8
+describe AmpArticlesController, 'base', type: :controller do
+  let!(:blog) { create(:blog) }
+
+  describe '#show' do
+    let!(:article) { create(:article, permalink: 'second-blog-article', published_at: '2004-04-01 02:00:00', updated_at: '2004-04-01 02:00:00', created_at: '2004-04-01 02:00:00') }
+    before(:each) do
+      get :show, from: "#{article.permalink}"
+    end
+
+    it 'should render template read to article' do
+      expect(response).to render_template('articles/amp/show')
+    end
+
+    it 'should assign article1 to @article' do
+      expect(assigns(:article)).to eq(article)
+    end
+  end
+end

--- a/spec/controllers/amp_articles_controller_spec.rb
+++ b/spec/controllers/amp_articles_controller_spec.rb
@@ -2,9 +2,9 @@
 describe AmpArticlesController, 'base', type: :controller do
   let!(:blog) { create(:blog) }
   let(:params) { {} }
+  let(:article) { create(:article, permalink: 'second-blog-article', published_at: '2004-04-01 02:00:00', updated_at: '2004-04-01 02:00:00', created_at: '2004-04-01 02:00:00', supports_amp: supports_amp) }
 
   describe '#show' do
-    let!(:article) { create(:article, permalink: 'second-blog-article', published_at: '2004-04-01 02:00:00', updated_at: '2004-04-01 02:00:00', created_at: '2004-04-01 02:00:00', supports_amp: supports_amp) }
     before(:each) do
       get :show, { from: "#{article.permalink}" }.merge(params)
     end
@@ -39,6 +39,20 @@ describe AmpArticlesController, 'base', type: :controller do
           expect(assigns(:article)).to eq(article)
         end
       end
+    end
+  end
+
+  describe '#article_body' do
+    let(:supports_amp) { true }
+    let(:processor) { double('AMPProcessor') }
+
+    before(:each) do
+      expect(AMPProcessor).to receive(:new).with(article).and_return(processor)
+      expect(processor).to receive(:call).and_return('body')
+    end
+
+    it 'returns some html' do
+      expect(subject.article_body(article)).to eq('body')
     end
   end
 end

--- a/spec/models/amp_processor_spec.rb
+++ b/spec/models/amp_processor_spec.rb
@@ -1,0 +1,59 @@
+# coding: utf-8
+describe AMPProcessor, type: :model do
+  let!(:blog) { create(:blog) }
+
+  let!(:blog) { create(:blog) }
+  let(:article) { create(:article, permalink: 'second-blog-article', published_at: '2004-04-01 02:00:00', updated_at: '2004-04-01 02:00:00', created_at: '2004-04-01 02:00:00', supports_amp: true) }
+  let(:processor) { AMPProcessor.new(article) }
+
+  describe '#call' do
+    before(:each) do
+      expect(article).to receive(:html).with(:body).and_return(body)
+    end
+
+    context 'no special tags in html' do
+      let(:body) { '<div>html</div>' }
+
+      it 'returns some html' do
+        expect(processor.call).to eq(body)
+      end
+    end
+
+    context 'blog contains an image tag' do
+      let(:src) { 'http://animage.com' }
+      let(:body) { "<img alt='something' src='#{src}'/>" }
+
+      before(:each) do
+        expect(FastImage).to receive(:size).with(src).and_return(fast_image_response)
+      end
+
+      context 'image exists' do
+        let(:fast_image_response) { [44, 52] }
+        let(:replaced_html) { "<amp-img alt=\"something\" src=\"#{src}\" layout=\"responsive\" width=\"44\" height=\"52\"></amp-img>" }
+
+        it 'replaces the image tag with an amp-image tag' do
+          expect(processor.call).to eq(replaced_html)
+        end
+      end
+
+      context 'image does not exists' do
+        let(:fast_image_response) { nil }
+
+        it 'removes the image tag' do
+          expect(processor.call).to eq('')
+        end
+      end
+    end
+
+    context 'blog contains an iframe' do
+      let(:src) { '//aniframe.com' }
+      let(:body) { "<iframe width='44' height='52' src='#{src}'/>" }
+
+        let(:replaced_html) { "<amp-iframe width=\"44\" height=\"52\" layout=\"responsive\" sandbox=\"allow-scripts allow-same-origin\" allowfullscreen frameborder=\"0\" src=\"https:#{src}\"></amp-iframe>" }
+
+        it 'replaces the iframe tag with an amp-iframe tag' do
+          expect(processor.call).to eq(replaced_html)
+        end
+    end
+  end
+end


### PR DESCRIPTION
This PR is very similar to https://github.com/moneyadviceservice/frontend/pull/1577.  It sets up a separate show view for blog posts so they can be viewed and comply to Google AMP.

# Changes in this PR
- We create an `/amp` sub-route for articles that returns a AMP compliant view. 
- We have created a separate Amp Articles controller 
  - This Subclasses `ActionController::Base` rather than `ApplicationController` because we need to limit everything that gets pulled into the view.
- We created a very basic view that only has AMP compliant HTML as well as various other AMP requirements (i.e. importing the AMP JS lib)
- We created a `amp_styles.scss` file.  This includes very little styles because AMP requires that styling is kept bellow 50Kb
- We link AMP Article views with Articles views and vice versa with canonical link tags.

![screenshot 2016-11-28 15 07 59](https://cloud.githubusercontent.com/assets/5196152/20673307/7f8dbc30-b57c-11e6-934a-99c7b0520d03.png)
