### PR TITLE
[DEV APPROVED] 7921 sitemap error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,8 +600,5 @@ DEPENDENCIES
   uuidtools (~> 2.1.1)
   webpurify
 
-RUBY VERSION
-   ruby 2.2.0p0
-
 BUNDLED WITH
    1.13.6

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -10,8 +10,6 @@ class SitemapsController < ApplicationController
           @items = Article.find_already_published(1000).news.where('published_at > ?', Time.now - 48.hours)
         else
           @items = Article.exclude_news.find_already_published(1000)
-          @items += Page.find_already_published(1000)
-          @items += Tag.find_all_with_article_counters unless this_blog.unindex_tags
         end
       end
     end

--- a/spec/controllers/sitemaps_controller_spec.rb
+++ b/spec/controllers/sitemaps_controller_spec.rb
@@ -5,7 +5,7 @@ describe SitemapsController, type: :controller do
   end
 
   describe '#show' do
-    context 'when the news param is set' do
+    context 'when the news param is not set' do
       before do
         FactoryGirl.create(:tag)
         get :show, format: 'xml'
@@ -20,7 +20,7 @@ describe SitemapsController, type: :controller do
       end
     end
 
-    context 'when the news param is not set' do
+    context 'when the news param is set' do
       before do
         FactoryGirl.create(:tag)
         get :show, format: 'xml', news: true

--- a/spec/views/sitemaps/show_xml_builder_spec.rb
+++ b/spec/views/sitemaps/show_xml_builder_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe 'sitemaps/show.xml.builder', type: :view do
+  describe 'rendered xml document' do
+    let!(:blog) { build_stubbed :blog }
+
+    before do
+      assign(:items, [article])
+
+      render
+    end
+
+    context 'untagged articles' do
+      let(:article) { create :article, permalink: 'how-to-save-a-life' }
+
+      it 'shows article sitemap' do
+        expect(rendered).to include('<loc>http://test.host/how-to-save-a-life</loc>')
+      end
+    end
+
+    context 'tagged articles' do
+      let(:tags) do
+        [
+          Tag.create(name: 'finance'),
+          Tag.create(name: 'debt management'),
+        ]
+      end
+
+      let(:article) { create :article, tags: tags, permalink: 'money-matters' }
+
+      it 'shows xml items for articles only' do
+        expect(rendered).to include('<loc>http://test.host/money-matters</loc>')
+      end
+
+      it 'does not show xml items for article tags' do
+        expect(rendered).to_not include('<loc>http://test.host/finance</loc>')
+        expect(rendered).to_not include('<loc>http://test.host/debt-management</loc>')
+      end
+    end
+  end
+
+  describe 'exclude page' do
+    it 'does not show page items' do
+      expect(rendered).to_not include('<loc>http://test.host/commenting-policy</loc>')
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes this [card](https://moneyadviceservice.tpondemand.com/entity/7921). 

**Pages** and **Tags** now are excluded from showing up in the _Sitemap_ XML document. Apart form the fact that they were throwing up blanks they have no SEO benefit. Pages, for instance, do not contain consumer focused article. See an example of a page [here](https://www.moneyadviceservice.org.uk/blog/pages/commenting-policy).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/publify/220)
<!-- Reviewable:end -->
