### PR TITLE
[DEV APPROVED]Fix atom and rss feeds

### DIFF
--- a/app/views/articles/read.html.erb
+++ b/app/views/articles/read.html.erb
@@ -1,6 +1,6 @@
 <% content_for :feeds do %>
-  <%= auto_discovery_link_tag :rss, article_url(@article, format: :rss) %>
-  <%= auto_discovery_link_tag :atom, article_url(@article, format: :atom) %>
+  <%= auto_discovery_link_tag :rss, rss_url( format: :rss) %>
+  <%= auto_discovery_link_tag :atom, atom_url( format: :atom) %>
 <% end %>
 
 <div class="l-banner">

--- a/app/views/author/show.html.erb
+++ b/app/views/author/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :feeds do %>
-  <%= auto_discovery_link_tag :rss, author_url(@author.login, format: :rss) %>
-  <%= auto_discovery_link_tag :atom, author_url(@author.login, format: :atom) %>
+  <%= auto_discovery_link_tag :rss, rss_url( format: :rss) %>
+  <%= auto_discovery_link_tag :atom, atom_url( format: :atom) %>
 <% end %>
 
 <div class="l-banner"></div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 20161129152334) do
     t.string   "description_meta_tag"
     t.integer  "primary_related_content_id"
     t.integer  "secondary_related_content_id"
-    t.boolean  "supports_amp",                             default: true
+    t.boolean  "supports_amp",                 default: true
   end
 
   add_index "contents", ["published"], name: "index_contents_on_published", using: :btree

--- a/spec/controllers/amp_articles_controller_spec.rb
+++ b/spec/controllers/amp_articles_controller_spec.rb
@@ -2,7 +2,7 @@
 describe AmpArticlesController, 'base', type: :controller do
   let!(:blog) { create(:blog) }
   let(:params) { {} }
-  let(:article) { create(:article, permalink: 'second-blog-article', published_at: '2004-04-01 02:00:00', updated_at: '2004-04-01 02:00:00', created_at: '2004-04-01 02:00:00', supports_amp: supports_amp) }
+  let(:article) { FactoryGirl.create(:article, permalink: 'second-blog-article', published_at: '2004-04-01 02:00:00', updated_at: '2004-04-01 02:00:00', created_at: '2004-04-01 02:00:00', supports_amp: supports_amp) }
 
   describe '#show' do
     before(:each) do

--- a/spec/models/amp_processor_spec.rb
+++ b/spec/models/amp_processor_spec.rb
@@ -3,7 +3,7 @@ describe AMPProcessor, type: :model do
   let!(:blog) { create(:blog) }
 
   let!(:blog) { create(:blog) }
-  let(:article) { create(:article, permalink: 'second-blog-article', published_at: '2004-04-01 02:00:00', updated_at: '2004-04-01 02:00:00', created_at: '2004-04-01 02:00:00', supports_amp: true) }
+  let(:article) { FactoryGirl.create(:article, permalink: 'second-blog-article', published_at: '2004-04-01 02:00:00', updated_at: '2004-04-01 02:00:00', created_at: '2004-04-01 02:00:00', supports_amp: true) }
   let(:processor) { AMPProcessor.new(article) }
 
   describe '#call' do


### PR DESCRIPTION
atom and RSS feeds on author and article pages were auto generating erroneous links into the header generating 404 errors when followed by crawlers