### PR TITLE
[DEV APPROVED] 8276 - Removes humans.txt from Blog

### DIFF
--- a/app/controllers/text_controller.rb
+++ b/app/controllers/text_controller.rb
@@ -1,8 +1,4 @@
 class TextController < ApplicationController
-  def humans
-    render text: this_blog.humans
-  end
-
   def robots
     render text: this_blog.robots
   end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -66,8 +66,7 @@ class Blog < ActiveRecord::Base
   setting :rss_description,            :boolean, false
   setting :rss_description_text,       :string, "<hr /><p><small>Original article written by %author% and published on <a href='%blog_url%'>%blog_name%</a> | <a href='%permalink_url%'>direct link to this article</a> | If you are reading this article anywhere other than on <a href='%blog_url%'>%blog_name%</a>, it has been illegally reproduced and without proper authorization.</small></p>"
   setting :robots,                     :string, 'User-agent: *\nAllow: /\nDisallow: /admin\n'
-  setting :humans,                     :string, "/* TEAM */\nYour title: Your name.\nSite: email, link to a contact form, etc.\nTwitter: your Twitter username.\n\n/* SITE */\nSoftware: Publify [http://publify.co] #{PUBLIFY_VERSION}"
-
+  
   setting :index_categories,           :boolean, true # deprecated but still needed for backward compatibility
   setting :unindex_categories,         :boolean, false
   setting :index_tags,                 :boolean, true # deprecated but still needed for backward compatibility

--- a/app/views/admin/settings/seo.html.erb
+++ b/app/views/admin/settings/seo.html.erb
@@ -98,17 +98,6 @@
   </fieldset>
 
   <fieldset class='form-horizontal'>
-    <legend><%= t(".human") %></legend>
-    <div class='form-group'>
-      <label class='control-label col-sm-2' for="setting_humans"><%= t(".humans_txt")%></label>
-      <div class='col-sm-5'>
-        <%= text_area(:setting, :humans, rows: 10, class: 'form-control')%>
-        <small class='help-block'><%= t(".explain_humans_txt") %></small>
-      </div>
-    </div>
-  </fieldset>
-
-  <fieldset class='form-horizontal'>
     <legend><%= t(".google") %></legend>
     <div class='form-group'>
       <label class='control-label col-sm-2' for="setting_google_analytics"><%= t(".google_analytics")%></label>

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -153,6 +153,3 @@ var MAS = (function(w, d) {
 <script type="text/javascript"><%= @content_for_script %></script>
 <%- end -%>
 <%= this_blog.custom_tracking_field unless this_blog.custom_tracking_field.blank? %>
-
-<link ref='author' href="humans.txt">
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -429,9 +429,6 @@ en:
         replaced_by_the_archive_date: "Replaced by the archive date"
         replaced_by_the_content_body: "Replaced by the content body"
       seo:
-        human: "Human"
-        humans_txt: "Human"
-        explain_humans_txt: "It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/"
         cancel: "Cancel"
         or: "or"
         update_settings: "Update settings"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,6 @@ Rails.application.routes.draw do
   get '/notes/page/:page', to: 'notes#index', format: false
   get '/note/:permalink', to: 'notes#show', as: :note, format: false
 
-  get '/humans', to: 'text#humans', format: 'txt'
   get '/robots', to: 'text#robots', format: 'txt'
 
   namespace :admin do

--- a/spec/controllers/text_controller_spec.rb
+++ b/spec/controllers/text_controller_spec.rb
@@ -1,13 +1,6 @@
 describe TextController, type: :controller do
   let!(:blog) { create(:blog) }
 
-  describe 'humans' do
-    before(:each) { get :humans, format: 'txt' }
-
-    it { expect(response).to be_success }
-    it { expect(response.body).to eq(blog.humans) }
-  end
-
   describe 'robots' do
     before(:each) { get :robots, format: 'txt' }
 

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -150,15 +150,4 @@ http://anotherurl.net/other_line")
     it { expect(blog.per_page('atom')).to eq(4) }
   end
 
-  describe '#humans' do
-    context 'default value with publify txt' do
-      let(:blog) { create :blog }
-      it { expect(blog.humans).to_not be_nil }
-    end
-
-    context 'default value with publify txt' do
-      let(:blog) { create(:blog, humans: 'something to say') }
-      it { expect(blog.humans).to eq('something to say') }
-    end
-  end
 end


### PR DESCRIPTION
# 8276 - Removes humans.txt from Blog

The Humans.txt file is causing tons of errors on the blog.  This PR removes the humans.txt file and the option from the admin interface (to prevent confusion for the content editors).

Tests have also been removed relating to this file.