### PR TITLE
add newrelic_ignore_enduser to amp articles controller

### DIFF
--- a/app/controllers/amp_articles_controller.rb
+++ b/app/controllers/amp_articles_controller.rb
@@ -1,4 +1,7 @@
 class AmpArticlesController < ActionController::Base
+
+  newrelic_ignore_enduser
+
   def show
     if (@article = Article.find_by_permalink(params[:from])).present?
       if @article.supports_amp? || params[:no_redirect]


### PR DESCRIPTION
TP #8388

https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=5D6AC326B4D272C23E446C28586BAF51#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=Bug/8388

Summary
add new relic_ignore_enduser call to amp_articles_controller to prevent new relic js script being injected into AMP pages

Testing
Tested on UAT