### PR TITLE
Fix postgresql syntax error, gem security vulnerabilities and remove legacy tech debt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://gems.dev.mas.local'
 
 gem 'dough-ruby', '~> 5.0', require: 'dough'
 
-gem 'pg'
+gem 'pg', '~> 0.15.1'
 gem 'rails', '~> 4.2.10'
 gem 'htmlentities'
 gem 'bluecloth', '~> 2.1'
@@ -22,7 +22,7 @@ gem 'recaptcha', require: 'recaptcha/rails'
 gem 'carrierwave', '~> 0.10.0'
 gem 'carrierwave-azure'
 gem 'akismet', '~> 1.0'
-gem 'twitter', '~> 5.6.0'
+gem 'twitter', '~> 6.2.0'
 gem 'jbuilder'
 gem 'webpurify', require: 'web_purify'
 gem 'rack-trailing_slashes'
@@ -82,7 +82,6 @@ group :test do
   gem 'site_prism'
   gem 'capybara'
   gem 'rspec_junit_formatter'
-  gem 'sqlite3'
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'http://gems.dev.mas.local'
 gem 'dough-ruby', '~> 5.0', require: 'dough'
 
 gem 'pg'
-gem 'rails', '~> 4.2'
+gem 'rails', '~> 4.2.10'
 gem 'htmlentities'
 gem 'bluecloth', '~> 2.1'
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,16 +115,14 @@ GEM
     csslint_ruby (0.0.2)
       execjs
     database_cleaner (1.6.2)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     docile (1.3.0)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.2.1)
-    dotenv-rails (2.2.1)
-      dotenv (= 2.2.1)
-      railties (>= 3.2, < 5.2)
+    dotenv (2.2.2)
+    dotenv-rails (2.2.2)
+      dotenv (= 2.2.2)
+      railties (>= 3.2, < 6.0)
     dough-ruby (5.27.0.306)
       activemodel
       activesupport
@@ -148,7 +146,7 @@ GEM
     flickraw (0.9.9)
     flickraw-cached (20120701)
       flickraw (>= 0.9)
-    fog (1.41.0)
+    fog (2.0.0)
       fog-aliyun (>= 0.1.0)
       fog-atmos
       fog-aws (>= 0.6.0)
@@ -165,6 +163,7 @@ GEM
       fog-json
       fog-local
       fog-openstack
+      fog-ovirt
       fog-powerdns (>= 0.1.1)
       fog-profitbricks
       fog-rackspace
@@ -181,7 +180,7 @@ GEM
       fog-xenserver
       fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
-      json (>= 1.8, < 2.0)
+      json (~> 2.0)
     fog-aliyun (0.2.0)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
@@ -243,6 +242,12 @@ GEM
       fog-core (~> 1.40)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
+    fog-ovirt (1.0.2)
+      fog-core (~> 1.45)
+      fog-json
+      fog-xml (~> 0.1.1)
+      ovirt-engine-sdk (>= 4.1.3)
+      rbovirt (~> 0.1.5)
     fog-powerdns (0.1.1)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
@@ -284,7 +289,7 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-vsphere (2.0.1)
+    fog-vsphere (2.1.0)
       fog-core
       rbvmomi (~> 1.9)
     fog-xenserver (0.3.0)
@@ -312,10 +317,14 @@ GEM
       uuidtools (>= 2.1.0)
     hike (1.2.3)
     htmlentities (4.3.4)
-    http (0.5.1)
-      http_parser.rb
+    http (3.0.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (>= 2.0.0.pre.pre2, < 3)
+      http_parser.rb (~> 0.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    http-form_data (2.1.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -331,7 +340,7 @@ GEM
       railties (>= 3.2.16)
     jshint_ruby (0.1)
       execjs
-    json (1.8.6)
+    json (2.1.0)
     jwt (1.5.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -389,10 +398,12 @@ GEM
       multi_xml (~> 0.5)
       rack (~> 1.2)
     orm_adapter (0.5.0)
+    ovirt-engine-sdk (4.2.3)
+      json (>= 1, < 3)
     parallel (1.12.1)
     parser (2.5.0.5)
       ast (~> 2.4.0)
-    pg (0.18.4)
+    pg (0.15.1)
     poltergeist (1.17.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -442,12 +453,15 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.0)
     rake (10.3.2)
+    rbovirt (0.1.5)
+      nokogiri
+      rest-client (> 1.7.0)
     rbvmomi (1.11.7)
       builder (~> 3.0)
       json (>= 1.8)
       nokogiri (~> 1.5)
       trollop (~> 2.1)
-    recaptcha (4.7.0)
+    recaptcha (4.8.0)
       json
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -496,7 +510,7 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simple_oauth (0.2.0)
+    simple_oauth (0.3.1)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -514,7 +528,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.13)
     subexec (0.2.3)
     syslog-logger (1.6.8)
     systemu (2.6.5)
@@ -524,18 +537,17 @@ GEM
     thread_safe (0.3.6)
     tilt (1.4.1)
     trollop (2.1.2)
-    twitter (5.6.0)
+    twitter (6.2.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
-      descendants_tracker (~> 0.0.3)
-      equalizer (~> 0.0.9)
-      faraday (~> 0.9.0)
-      http (~> 0.5.0)
+      equalizer (~> 0.0.11)
+      http (~> 3.0)
+      http-form_data (~> 2.0)
       http_parser.rb (~> 0.6.0)
-      json (~> 1.8)
       memoizable (~> 0.4.0)
+      multipart-post (~> 2.0)
       naught (~> 1.0)
-      simple_oauth (~> 0.2.0)
+      simple_oauth (~> 0.3.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.8)
@@ -603,7 +615,7 @@ DEPENDENCIES
   nokogiri
   non-stupid-digest-assets
   oauth2 (= 1.0.0)
-  pg
+  pg (~> 0.15.1)
   poltergeist
   pry-rails
   rack-trailing_slashes
@@ -621,9 +633,8 @@ DEPENDENCIES
   sass-rails (~> 4.0.3)
   simplecov
   site_prism
-  sqlite3
   syslog-logger
-  twitter (~> 5.6.0)
+  twitter (~> 6.2.0)
   uglifier
   unicorn
   uuidtools (~> 2.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     compass-rails (2.0.0)
       compass (>= 0.12.2)
     concurrent-ruby (1.0.5)
-    crass (1.0.3)
+    crass (1.0.4)
     csslint_ruby (0.0.2)
       execjs
     database_cleaner (1.6.2)
@@ -392,7 +392,7 @@ GEM
     parallel (1.12.1)
     parser (2.5.0.5)
       ast (~> 2.4.0)
-    pg (0.15.1)
+    pg (0.18.4)
     poltergeist (1.17.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -607,7 +607,7 @@ DEPENDENCIES
   poltergeist
   pry-rails
   rack-trailing_slashes
-  rails (~> 4.2.7)
+  rails (~> 4.2.10)
   rails-observers (~> 0.1.2)
   rails-timeago (~> 2.0)
   rails_autolink (~> 1.1.0)
@@ -629,9 +629,6 @@ DEPENDENCIES
   uuidtools (~> 2.1.1)
   webpurify
   xmlrpc
-
-RUBY VERSION
-   ruby 2.4.2p198
 
 BUNDLED WITH
    1.16.1

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Publify has been around since 2004 and is the oldest Ruby on Rails open source p
 
 #### Prerequisites
 
-- Ruby 2.1.3
+- Ruby 2.4.2
 - Node.js
 - Bower
 - MYSQL

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -17,7 +17,7 @@ class Admin::DashboardController < Admin::BaseController
     @statsdrafts = Article.drafts.where('created_at > ?', today).count
     @statspages = Page.where('published_at > ?', today).count
     @statuses = Note.where('published_at > ?', today).count
-    @statuserposts = Article.published.where('published_at > ?', today).group(:user_id).count
+    @statuserposts = Article.published.where('published_at > ?', today).group(:user_id, :published_at).count
     @statcomments = Comment.where('created_at > ?', today).count
     @presumedspam = Comment.presumed_spam.where('created_at > ?', today).count
     @confirmed = Comment.ham.where('created_at > ?', today).count

--- a/bin/setup
+++ b/bin/setup
@@ -22,22 +22,5 @@ cp config/database.yml.postgres config/database.yml
 # Set up database and add any development seed data
 bundle exec rake db:create db:migrate db:seed db:test:prepare
 
-# Set up staging and production git remotes.
-git remote add staging git@heroku.com:mas-marketing-blog-staging.git || true
-git remote add production git@heroku.com:mas-marketing-blog.git || true
-
-# Join the staging and production apps.
-if heroku join --app mas-marketing-blog-staging &> /dev/null; then
-  echo 'You are a collaborator on the "mas-marketing-blog-staging" Heroku app'
-else
-  echo 'Ask for access to the "mas-marketing-blog-staging" Heroku app'
-fi
-
-if heroku join --app mas-marketing-blog &> /dev/null; then
-  echo 'You are a collaborator on the "mas-marketing-blog" Heroku app'
-else
-  echo 'Ask for access to the "mas-marketing-blog" Heroku app'
-fi
-
 # This needs fixing
 #bundle exec rake generate_popular_articles

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,10 +11,8 @@ development:
   <<: *login
 
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
+  database: blog_test
+  <<: *login
 
 production:
   adapter: postgresql

--- a/config/database.yml.postgres
+++ b/config/database.yml.postgres
@@ -11,10 +11,8 @@ development:
   <<: *login
 
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
+  database: blog_test
+  <<: *login
 
 production:
   adapter: postgresql


### PR DESCRIPTION
- This PR fixes a PG Syntax error that was missed when running rspec tests locally, 
the test script was previously set to run using sqlite3 locally and syntax error not applicable when using mysql/sqlite3.

- update gems including http 0.5.0 > 3.0.0 to fix security vulnerability

- remove obsolete heroku config from app setup script