### PR TITLE
[DEV APPROVED] Order users by id instead of login

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,19 +2,19 @@ class Admin::UsersController < Admin::BaseController
   cache_sweeper :blog_sweeper
 
   def index
-    @users = User.order('login asc').page(params[:page]).per(this_blog.admin_display_elements)
+    @users = User.order(:id).page(params[:page]).per(this_blog.admin_display_elements)
   end
 
   def new
     @user = User.new
     @profiles = Profile.order('id')
   end
-  
+
   def create
     @user = User.new(params[:user].permit!)
     @user.text_filter = TextFilter.find_by_name(this_blog.text_filter)
     @user.name = @user.login
-    
+
     if @user.save
       flash[:success] = I18n.t('admin.users.create.success')
       redirect_to admin_users_path
@@ -28,10 +28,10 @@ class Admin::UsersController < Admin::BaseController
     @user = User.find(params[:id])
     @profiles = Profile.order('id')
   end
-  
+
   def update
     @user = User.find(params[:id])
-    
+
     if @user.update_attributes(params[:user].permit!)
       flash[:success] = I18n.t('admin.users.update.success')
       redirect_to admin_users_path


### PR DESCRIPTION
The login column is now encrypted. Use ID column instead to order in Manage Users.