### PR TITLE
lock blind_index gem to 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://gems.dev.mas.local'
 
 gem 'dough-ruby', '~> 5.0', require: 'dough'
 gem 'attr_encrypted', '~> 3.1'
-gem 'blind_index'
+gem 'blind_index', '0.2.0'
 
 gem 'attr_encrypted', '~> 3.1'
 gem 'pg', '~> 0.15.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -585,7 +585,7 @@ DEPENDENCIES
   akismet (~> 1.0)
   attr_encrypted (~> 3.1)
   autoprefixer-rails
-  blind_index
+  blind_index (= 0.2.0)
   bluecloth (~> 2.1)
   bowndler (~> 1.0)
   byebug


### PR DESCRIPTION
Updating the version of blind_index can invalidate the indexs in the DB.

Locking the version to prevent accidental version updates