### PR TITLE
[DEV APPROVED] Fix ckeditor path helper usage from the host app

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,9 +38,9 @@ Rails.application.routes.draw do
 
   get '/robots', to: 'text#robots', format: 'txt'
 
-  namespace :admin do
-    mount Ckeditor::Engine => '/ckeditor', as: 'ckeditor'
+  mount Ckeditor::Engine => '/admin/ckeditor', as: 'ckeditor'
 
+  namespace :admin do
     get '/', to: 'dashboard#index', as: 'dashboard'
 
     resources :popular_articles, only: [:new, :create]


### PR DESCRIPTION
`ckeditor` tries to access a path helper relying on the fact that the engine's prefix name will always be respected and be equal to `ckeditor` when mounted into the host app.

When mounting inside a namespace, Rails will actually prepend the namespace to the route's prefix.

This PR moves the mounted route outside of the `admin` (Rails') "namespace".

BTW, an engine should not rely on something defined for the host app only (the mount point).

Please refer to this commit and comment: https://github.com/galetahub/ckeditor/commit/de6167a38394174d5c2e4543da804c3675c121dd#commitcomment-14412106